### PR TITLE
Change in option parsing

### DIFF
--- a/plugin/src/main/scala/com/typesafe/genjavadoc/Plugin.scala
+++ b/plugin/src/main/scala/com/typesafe/genjavadoc/Plugin.scala
@@ -18,18 +18,18 @@ class GenJavaDocPlugin(val global: Global) extends Plugin {
   val components = List[PluginComponent](MyComponent)
 
   override def processOptions(options: List[String], error: String ⇒ Unit): Unit = {
-    this.options = new Properties()
+    this.opts = new Properties()
     options foreach { str ⇒
       str.indexOf('=') match {
-        case -1 ⇒ this.options.setProperty(str, "true")
-        case n  ⇒ this.options.setProperty(str.substring(0, n), str.substring(n + 1))
+        case -1 ⇒ opts.setProperty(str, "true")
+        case n  ⇒ opts.setProperty(str.substring(0, n), str.substring(n + 1))
       }
     }
   }
-  var options: Properties = _
+  var opts: Properties = _
 
-  lazy val outputBase = new File(options.getProperty("out", "."))
-  lazy val suppressSynthetic = java.lang.Boolean.parseBoolean(options.getProperty("suppressSynthetic", "true"))
+  lazy val outputBase = new File(opts.getProperty("out", "."))
+  lazy val suppressSynthetic = java.lang.Boolean.parseBoolean(opts.getProperty("suppressSynthetic", "true"))
 
   private object MyComponent extends PluginComponent with Transform {
 


### PR DESCRIPTION
This change is necessary in order to work around
the introduction of a method called "options" in
scala's commit f3731f9ace5d3d5e213ea786fe0027ea66c5358b.

Please note that, due to further changes in 2.11.0-M6,
the 'expected_output' content will need to be updated;
the tests are currently failing on M6+, since some of the
output is now slightly different.
