### PR TITLE
Don't fail for deprecated lazy vals, fixes #85.

### DIFF
--- a/plugin/src/test/resources/expected_output/basic/akka/rk/buh/is/it/DeprecatedNoComment.java
+++ b/plugin/src/test/resources/expected_output/basic/akka/rk/buh/is/it/DeprecatedNoComment.java
@@ -8,4 +8,9 @@ public class DeprecatedNoComment {
    * @deprecated This is replaced by theShinyNewMethod. Since now.
    */
   public  void oldMethod () { throw new RuntimeException(); }
+  private  void oldLazyVal$lzycompute ()  { throw new RuntimeException(); }
+  /**
+   * @deprecated This is replaced by theShinyNewLazyVal. Since now.
+   */
+  public  void oldLazyVal ()  { throw new RuntimeException(); }
 }

--- a/plugin/src/test/resources/input/basic/test.scala
+++ b/plugin/src/test/resources/input/basic/test.scala
@@ -273,6 +273,9 @@ private[it] class DontTouchThis {
 class DeprecatedNoComment {
   @deprecated("This is replaced by theShinyNewMethod", since = "now")
   def oldMethod = ()
+
+  @deprecated("This is replaced by theShinyNewLazyVal", since = "now")
+  lazy val oldLazyVal= ()
 }
 
 


### PR DESCRIPTION
This somewhat fixes #85 so that genjavadoc does at least not fail. However,
like in the case for deprecated lazy vals with preexisting scaladoc, the
preexisting comment might be lost under some Scala versions.

The reason seems to be that starting from Scala 2.12 positions are reported
in a way that puts the original position on the private `$lzycompute` method
instead of on the accessor. To fix that additional considerations are necessary
to somehow reconcile position information from the lzycompute with the actual
accessor so that existing and generated scaladoc can be merged.