### PR TITLE
Correctly flatten members of a class

### DIFF
--- a/plugin/src/main/scala/com/typesafe/genjavadoc/AST.scala
+++ b/plugin/src/main/scala/com/typesafe/genjavadoc/AST.scala
@@ -39,6 +39,9 @@ trait AST { this: TransformCake ⇒
       ret
     }
 
+    def classMembers = members.collect { case classInfo: ClassInfo => classInfo }
+    def methodMembers = members.collect { case methodInfo: MethodInfo => methodInfo }
+
     override def toString =
       s"ClassInfo($name, ${pattern("XXXXX", "AAAAA")}, module=$module, pckg=$pckg, ${filepattern("FFFFFF")}, interface=$interface, static=$static)" +
         comment.mkString("\n  ", "\n  ", "\n  ") + members.mkString("\n  ")

--- a/plugin/src/main/scala/com/typesafe/genjavadoc/Output.scala
+++ b/plugin/src/main/scala/com/typesafe/genjavadoc/Output.scala
@@ -75,7 +75,7 @@ trait Output { this: TransformCake ⇒
         case (Some(o), Some(c))            ⇒ merge(o, c, forwarders, staticScope)
         case (Some(o), None) if forwarders ⇒ merge(o, fabricateCompanion(o), forwarders, staticScope)
         case (Some(o), None)               ⇒ Vector(mangleModule(o, addMODULE = forwarders, pruneClasses = false))
-        case (None, Some(c))               ⇒ Vector(c.copy(members = flatten(c.classMembers) ++ c.methodMembers))
+        case (None, Some(c))               ⇒ Vector(c.copy(members = flatten(c.classMembers) ++ c.methodMembers.sortBy(_.name)))
         case (None, None)                  ⇒ ???
       }
     }

--- a/plugin/src/main/scala/com/typesafe/genjavadoc/Output.scala
+++ b/plugin/src/main/scala/com/typesafe/genjavadoc/Output.scala
@@ -104,7 +104,12 @@ trait Output { this: TransformCake ⇒
         Some(MethodInfo(x ⇒ x, "public static final", s"${obj.name}$$ MODULE$$ = null;",
           Seq("/**", " * Static reference to the singleton instance of this Scala object.", " */")))
       else None
-    val members = (moduleInstance ++: obj.members) filter (!pruneClasses || _.isInstanceOf[MethodInfo])
+
+    val members = moduleInstance ++: (
+      if (pruneClasses) obj.methodMembers
+      else flatten(obj.classMembers) ++ obj.methodMembers
+      )
+
     val (com: Seq[String], moduleMembers: Vector[Templ]) = ((obj.comment, Vector.empty[Templ]) /: members)((p, mem) ⇒ mem match {
       case x: MethodInfo if x.name == obj.name ⇒ (p._1 ++ x.comment, p._2 :+ x.copy(name = x.name + '$', comment = Seq()))
       case x                                   ⇒ (p._1, p._2 :+ x)

--- a/plugin/src/main/scala/com/typesafe/genjavadoc/Output.scala
+++ b/plugin/src/main/scala/com/typesafe/genjavadoc/Output.scala
@@ -147,11 +147,11 @@ trait Output { this: TransformCake ⇒
     if (forwarders) {
       val base = cls.copy(members = nestedClasses ++ nestedStaticClasses ++ staticMethods ++ methods)
       val mod = mangleModule(obj, addMODULE = forwarders, pruneClasses = true)
-      Vector(base) ++ Vector(mod)
+      Vector(base, mod)
     } else {
       val base = cls.copy(members = nestedClasses ++ staticMethods ++ methods)
       val mod = mangleModule(obj, addMODULE = forwarders, pruneClasses = true)
-      Vector(base) ++ Vector(mod.copy(members = nestedStaticClasses ++ mod.members))
+      Vector(base, mod.copy(members = nestedStaticClasses ++ mod.members))
     }
   }
 

--- a/plugin/src/test/resources/expected_output/basic/akka/rk/buh/is/it/A.java
+++ b/plugin/src/test/resources/expected_output/basic/akka/rk/buh/is/it/A.java
@@ -60,11 +60,6 @@ public  class A {
    * class A.B
    */
   public  class B implements akka.rk.buh.is.it.X {
-    /**
-     * def b(args: java.lang.String*): Unit
-     * @param args (undocumented)
-     */
-    public  void b (java.lang.String... args)  { throw new RuntimeException(); }
     // not preceding
     public   B ()  { throw new RuntimeException(); }
     /**
@@ -76,13 +71,18 @@ public  class A {
      * def b(args: java.lang.String*): Unit
      * @param args (undocumented)
      */
+    public  void b (java.lang.String... args)  { throw new RuntimeException(); }
+    /**
+     * def b(args: java.lang.String*): Unit
+     * @param args (undocumented)
+     */
     public  void b (scala.collection.Seq<java.lang.String> args)  { throw new RuntimeException(); }
     public  java.lang.String d (java.lang.String a, akka.rk.buh.is.it.X b)  { throw new RuntimeException(); }
   }
   public  class C implements akka.rk.buh.is.it.X {
-    public  int i ()  { throw new RuntimeException(); }
     // not preceding
     public   C ()  { throw new RuntimeException(); }
+    public  int i ()  { throw new RuntimeException(); }
   }
   /**
    * class A.C

--- a/plugin/src/test/resources/expected_output/basic/akka/rk/buh/is/it/AnAbstractTypeRef.java
+++ b/plugin/src/test/resources/expected_output/basic/akka/rk/buh/is/it/AnAbstractTypeRef.java
@@ -3,7 +3,6 @@ package akka.rk.buh.is.it;
  * AbstractTypeRef
  */
 public  interface AnAbstractTypeRef {
-  public  akka.rk.buh.is.it.AnAbstractTypeRef someMethod () ;
   /**
    * And a parameter type ref.
    * @param t (undocumented)
@@ -11,4 +10,5 @@ public  interface AnAbstractTypeRef {
    * @return (undocumented)
    */
   public  akka.rk.buh.is.it.PTrait otherMethod (akka.rk.buh.is.it.PTrait t, java.lang.String string) ;
+  public  akka.rk.buh.is.it.AnAbstractTypeRef someMethod () ;
 }

--- a/plugin/src/test/resources/expected_output/basic/akka/rk/buh/is/it/ClassWithInner.java
+++ b/plugin/src/test/resources/expected_output/basic/akka/rk/buh/is/it/ClassWithInner.java
@@ -1,0 +1,18 @@
+package akka.rk.buh.is.it;
+public  class ClassWithInner {
+  public  class Foo {
+    static public  int companionObjectValue ()  { throw new RuntimeException(); }
+    public   Foo ()  { throw new RuntimeException(); }
+    public  int methodOfFoo (int i)  { throw new RuntimeException(); }
+  }
+  public  class Foo$ {
+    /**
+     * Static reference to the singleton instance of this Scala object.
+     */
+    public static final Foo$ MODULE$ = null;
+    public   Foo$ ()  { throw new RuntimeException(); }
+    public  int companionObjectValue ()  { throw new RuntimeException(); }
+  }
+  public  akka.rk.buh.is.it.ClassWithInner.Foo$ Foo ()  { throw new RuntimeException(); }
+  public   ClassWithInner ()  { throw new RuntimeException(); }
+}

--- a/plugin/src/test/resources/expected_output/basic/akka/rk/buh/is/it/ClassWithInner.java
+++ b/plugin/src/test/resources/expected_output/basic/akka/rk/buh/is/it/ClassWithInner.java
@@ -13,6 +13,6 @@ public  class ClassWithInner {
     public   Foo$ ()  { throw new RuntimeException(); }
     public  int companionObjectValue ()  { throw new RuntimeException(); }
   }
-  public  akka.rk.buh.is.it.ClassWithInner.Foo$ Foo ()  { throw new RuntimeException(); }
   public   ClassWithInner ()  { throw new RuntimeException(); }
+  public  akka.rk.buh.is.it.ClassWithInner.Foo$ Foo ()  { throw new RuntimeException(); }
 }

--- a/plugin/src/test/resources/expected_output/basic/akka/rk/buh/is/it/CompressionProtocol$.java
+++ b/plugin/src/test/resources/expected_output/basic/akka/rk/buh/is/it/CompressionProtocol$.java
@@ -1,0 +1,8 @@
+package akka.rk.buh.is.it;
+public  class CompressionProtocol$ {
+  /**
+   * Static reference to the singleton instance of this Scala object.
+   */
+  public static final CompressionProtocol$ MODULE$ = null;
+  public   CompressionProtocol$ ()  { throw new RuntimeException(); }
+}

--- a/plugin/src/test/resources/expected_output/basic/akka/rk/buh/is/it/CompressionProtocol.java
+++ b/plugin/src/test/resources/expected_output/basic/akka/rk/buh/is/it/CompressionProtocol.java
@@ -1,0 +1,47 @@
+package akka.rk.buh.is.it;
+public  class CompressionProtocol {
+  static public  class Events$ {
+    /**
+     * Static reference to the singleton instance of this Scala object.
+     */
+    public static final Events$ MODULE$ = null;
+    public final class HeavyHitterDetected implements akka.rk.buh.is.it.CompressionProtocol.Events.Event, scala.Product, scala.Serializable {
+      static public  akka.rk.buh.is.it.CompressionProtocol.Events.HeavyHitterDetected apply (Object key, int id, long count)  { throw new RuntimeException(); }
+      static public  scala.Option<scala.Tuple3<java.lang.Object, java.lang.Object, java.lang.Object>> unapply (akka.rk.buh.is.it.CompressionProtocol.Events.HeavyHitterDetected x$0)  { throw new RuntimeException(); }
+      static private  java.lang.Object readResolve ()  { throw new RuntimeException(); }
+      public  Object key ()  { throw new RuntimeException(); }
+      public  int id ()  { throw new RuntimeException(); }
+      public  long count ()  { throw new RuntimeException(); }
+      // not preceding
+      public   HeavyHitterDetected (Object key, int id, long count)  { throw new RuntimeException(); }
+      public  akka.rk.buh.is.it.CompressionProtocol.Events.HeavyHitterDetected copy (Object key, int id, long count)  { throw new RuntimeException(); }
+      // not preceding
+      public  Object copy$default$1 ()  { throw new RuntimeException(); }
+      public  int copy$default$2 ()  { throw new RuntimeException(); }
+      public  long copy$default$3 ()  { throw new RuntimeException(); }
+      // not preceding
+      public  java.lang.String productPrefix ()  { throw new RuntimeException(); }
+      public  int productArity ()  { throw new RuntimeException(); }
+      public  Object productElement (int x$1)  { throw new RuntimeException(); }
+      public  scala.collection.Iterator<java.lang.Object> productIterator ()  { throw new RuntimeException(); }
+      public  boolean canEqual (Object x$1)  { throw new RuntimeException(); }
+      public  int hashCode ()  { throw new RuntimeException(); }
+      public  java.lang.String toString ()  { throw new RuntimeException(); }
+      public  boolean equals (Object x$1)  { throw new RuntimeException(); }
+    }
+    public  class HeavyHitterDetected$ extends scala.runtime.AbstractFunction3<java.lang.Object, java.lang.Object, java.lang.Object, akka.rk.buh.is.it.CompressionProtocol.Events.HeavyHitterDetected> implements scala.Serializable {
+      /**
+       * Static reference to the singleton instance of this Scala object.
+       */
+      public static final HeavyHitterDetected$ MODULE$ = null;
+      public   HeavyHitterDetected$ ()  { throw new RuntimeException(); }
+      public final  java.lang.String toString ()  { throw new RuntimeException(); }
+      public  akka.rk.buh.is.it.CompressionProtocol.Events.HeavyHitterDetected apply (Object key, int id, long count)  { throw new RuntimeException(); }
+      public  scala.Option<scala.Tuple3<java.lang.Object, java.lang.Object, java.lang.Object>> unapply (akka.rk.buh.is.it.CompressionProtocol.Events.HeavyHitterDetected x$0)  { throw new RuntimeException(); }
+      private  java.lang.Object readResolve ()  { throw new RuntimeException(); }
+    }
+    public  interface Event {
+    }
+    public   Events$ ()  { throw new RuntimeException(); }
+  }
+}

--- a/plugin/src/test/resources/expected_output/basic/akka/rk/buh/is/it/DontTouchThis.java
+++ b/plugin/src/test/resources/expected_output/basic/akka/rk/buh/is/it/DontTouchThis.java
@@ -7,13 +7,13 @@ package akka.rk.buh.is.it;
 public class DontTouchThis {
   public   DontTouchThis () { throw new RuntimeException(); }
   /**
+   * @deprecated This is already deprecated. Since now.
+   */
+  public void alreadyDeprecatedInComment () { throw new RuntimeException(); }
+  /**
    * Some methods are forever.
    *
    * @deprecated This is replaced by someDiamondsAre. Since now.
    */
   public void orNotSoMuch () { throw new RuntimeException(); }
-  /**
-   * @deprecated This is already deprecated. Since now.
-   */
-  public void alreadyDeprecatedInComment () { throw new RuntimeException(); }
 }

--- a/plugin/src/test/resources/expected_output/strict_visibility/org/example/Clazz.java
+++ b/plugin/src/test/resources/expected_output/strict_visibility/org/example/Clazz.java
@@ -1,9 +1,9 @@
 package org.example;
 class Clazz {
     public Clazz () { throw new RuntimeException(); }
+    private void t () { throw new RuntimeException(); }
+    public void u () { throw new RuntimeException(); }
     private void x () { throw new RuntimeException(); }
     void y () { throw new RuntimeException(); }
     void z () { throw new RuntimeException(); }
-    private void t () { throw new RuntimeException(); }
-    public void u () { throw new RuntimeException(); }
 }

--- a/plugin/src/test/resources/expected_output/strict_visibility/org/example/PublicClazz.java
+++ b/plugin/src/test/resources/expected_output/strict_visibility/org/example/PublicClazz.java
@@ -1,13 +1,13 @@
 package org.example;
 public class PublicClazz {
     public PublicClazz () { throw new RuntimeException(); }
-    private void x () { throw new RuntimeException(); }
-    void y () { throw new RuntimeException(); }
-    void z () { throw new RuntimeException(); }
     private void t () { throw new RuntimeException(); }
     public void u () { throw new RuntimeException(); }
     void v2 () { throw new RuntimeException(); }
     void v3 () { throw new RuntimeException(); }
     private void v4 () { throw new RuntimeException(); }
     public void v5 () { throw new RuntimeException(); }
+    private void x () { throw new RuntimeException(); }
+    void y () { throw new RuntimeException(); }
+    void z () { throw new RuntimeException(); }
 }

--- a/plugin/src/test/resources/input/basic/test.scala
+++ b/plugin/src/test/resources/input/basic/test.scala
@@ -390,3 +390,15 @@ class ClassWithInner {
   }
 
 }
+
+private[buh] object CompressionProtocol {
+
+  private[buh] object Events {
+
+    private[buh] sealed trait Event
+
+    final case class HeavyHitterDetected(key: Any, id: Int, count: Long) extends Event
+
+  }
+
+}

--- a/plugin/src/test/resources/input/basic/test.scala
+++ b/plugin/src/test/resources/input/basic/test.scala
@@ -379,3 +379,14 @@ abstract class Reserved {
 }
 
 object ReservedImpl extends Reserved
+
+class ClassWithInner {
+
+  class Foo {
+    def methodOfFoo(i: Int) = 42
+  }
+  object Foo {
+    val companionObjectValue = 32
+  }
+
+}


### PR DESCRIPTION
When a class (i.e. `ClassWithInner`) contains another class (i.e. `Foo`) with
a companion object, the companion object class was not properly flattened with
the explicit class, leading to 2 inner classes (and thus invalid Java code)