### PR TITLE
Travis makes us work harder now to actually get OpenJDK 6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,11 @@ cache:
 
 language: scala
 
+addons:
+  apt:
+    packages:
+      - openjdk-6-jdk
+
 jdk:
   - openjdk6
   - oraclejdk8


### PR DESCRIPTION
as per:
https://github.com/travis-ci/travis-ci/issues/8199#issuecomment-327246053

an example run where we asked for 6 but got 8: https://travis-ci.org/lightbend/genjavadoc/jobs/282667570