### PR TITLE
fix test failure in Scala community build

### DIFF
--- a/plugin/src/test/resources/patches/2.12.5.patch
+++ b/plugin/src/test/resources/patches/2.12.5.patch
@@ -1,0 +1,53 @@
+--- target/expected_output/basic/akka/rk/buh/is/it/A.java
++++ target/expected_output/basic/akka/rk/buh/is/it/A.java
+@@ -48,13 +48,13 @@
+     public  class NonStatic {
+       public   NonStatic ()  { throw new RuntimeException(); }
+     }
++    public  akka.rk.buh.is.it.A.D$.E$ E ()  { throw new RuntimeException(); }
+     public   D$ ()  { throw new RuntimeException(); }
+     /**
+      * def A.D.math
+      * @return (undocumented)
+      */
+     public  long math ()  { throw new RuntimeException(); }
+-    public  akka.rk.buh.is.it.A.D$.E$ E ()  { throw new RuntimeException(); }
+   }
+   /**
+    * class A.B
+@@ -94,12 +94,12 @@
+     public  class C1$ {
+       public   C1$ ()  { throw new RuntimeException(); }
+     }
+-    public   C1 ()  { throw new RuntimeException(); }
+     /**
+      * Accessor for nested Scala object
+      * @return (undocumented)
+      */
+     public  akka.rk.buh.is.it.A.C1.C1$ C1 ()  { throw new RuntimeException(); }
++    public   C1 ()  { throw new RuntimeException(); }
+   }
+   /**
+    * object C1
+@@ -147,6 +147,11 @@
+   static public  java.lang.String stattic ()  { throw new RuntimeException(); }
+   static public  java.lang.Object x ()  { throw new RuntimeException(); }
+   /**
++   * Accessor for nested Scala object
++   * @return (undocumented)
++   */
++  public  akka.rk.buh.is.it.A.D$ D ()  { throw new RuntimeException(); }
++  /**
+    * varargs
+    * @param s (undocumented)
+    * @return (undocumented)
+@@ -219,9 +224,4 @@
+    */
+   public  int testthrows () throws java.lang.IllegalArgumentException, java.lang.NullPointerException { throw new RuntimeException(); }
+   public  scala.runtime.Null$ getNull ()  { throw new RuntimeException(); }
+-  /**
+-   * Accessor for nested Scala object
+-   * @return (undocumented)
+-   */
+-  public  akka.rk.buh.is.it.A.D$ D ()  { throw new RuntimeException(); }
+ }

--- a/plugin/src/test/scala/com/typesafe/genjavadoc/BasicSpec.scala
+++ b/plugin/src/test/scala/com/typesafe/genjavadoc/BasicSpec.scala
@@ -21,7 +21,11 @@ class BasicSpec extends WordSpec with Matchers with CompilerSpec {
   override def sources = BasicSpec.sources
   override def expectedPath: String = {
 
-    val patchFile = s"src/test/resources/patches/${scala.util.Properties.versionNumberString}.patch"
+    // nightly Scala versions have version numbers like "2.12.5-bin-3792784".
+    // we just want the "2.12.5" part
+    val scalaVersion = scala.util.Properties.versionNumberString.split("-bin-").head
+
+    val patchFile = s"src/test/resources/patches/$scalaVersion.patch"
     if (new java.io.File(patchFile).exists) { // we have a patch to apply to expected output for this scala version
       "rm -rf target/expected_output".! // cleanup from previous runs
       "cp -r src/test/resources/expected_output target/".! // copy expected output to a place which is going to be patched


### PR DESCRIPTION
by supporting Scala nightly version numbers in general

context: scala/community-builds#657