### PR TITLE
avoid deprecated one-argument assert in compiler

### DIFF
--- a/plugin/src/main/scala/com/typesafe/genjavadoc/JavaSig.scala
+++ b/plugin/src/main/scala/com/typesafe/genjavadoc/JavaSig.scala
@@ -114,7 +114,7 @@ trait JavaSig { this: TransformCake ⇒
             name + generics
           } else jsig(erasure.erasure(sym0)(tp), existentiallyBound, toplevel, primitiveOK)
         case PolyType(tparams, restpe) ⇒
-          assert(tparams.nonEmpty)
+          assert(tparams.nonEmpty, s"expected non-empty type parameters in $tp")
           if (toplevel) polyParamSig(tparams) else ""
 
         case MethodType(params, restpe) ⇒


### PR DESCRIPTION
new deprecation coming in 2.12.5

caught by the Scala 2.12 community build