### PR TITLE
Compile with 2.13.0-M4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ env:
   - SCALA_VERSION=2.12.4
   - SCALA_VERSION=2.12.5
   - SCALA_VERSION=2.12.6
-  - SCALA_VERSION=2.13.0-M3
+  - SCALA_VERSION=2.13.0-M4
 
 # there's no better way it seems.. https://github.com/travis-ci/travis-ci/issues/1519
 matrix:
@@ -52,7 +52,7 @@ matrix:
     - jdk: openjdk6
       env: SCALA_VERSION=2.12.6
     - jdk: openjdk6
-      env: SCALA_VERSION=2.13.0-M3
+      env: SCALA_VERSION=2.13.0-M4
 
 # Increasing ReservedCodeCacheSize minimizes scala compiler-interface compile times
 script:

--- a/plugin/src/main/scala/com/typesafe/genjavadoc/BaseComments.scala
+++ b/plugin/src/main/scala/com/typesafe/genjavadoc/BaseComments.scala
@@ -36,8 +36,8 @@ trait BaseComments { this: TransformCake ⇒
               s"$prefix$link"
           case x ⇒ x
         }
-        .map(line ⇒ (line /: replacements) { case (l, (from, to)) ⇒ l.replace(from, to) })
-      val (_, _, _, l2) = ((false, false, true, List.empty[String]) /: ll) {
+        .map(line ⇒ replacements.foldLeft(line) { case (l, (from, to)) ⇒ l.replace(from, to) })
+      val (_, _, _, l2) = ll.foldLeft((false, false, true, List.empty[String])) {
         // insert <p> line upon transition to empty, collapse contiguous empty lines
         case ((pre, code, empty, lines), line @ EmptyLine()) ⇒
           val nl =

--- a/plugin/src/main/scala/com/typesafe/genjavadoc/BasicTransform.scala
+++ b/plugin/src/main/scala/com/typesafe/genjavadoc/BasicTransform.scala
@@ -147,11 +147,11 @@ trait BasicTransform { this: TransformCake ⇒
     ret
   }
 
-  private def addMethod(d: DefDef, comment: Seq[String]) {
+  private def addMethod(d: DefDef, comment: Seq[String]): Unit = {
     clazz = clazz map (c ⇒ c.addMember(MethodInfo(d, c.interface, comment, hasVararg = false, deprecation = deprecationInfo(d))))
   }
 
-  private def addVarargsMethod(d: DefDef, comment: Seq[String]) {
+  private def addVarargsMethod(d: DefDef, comment: Seq[String]): Unit = {
     clazz = clazz map (c ⇒ c.addMember(MethodInfo(d, c.interface, comment, hasVararg = true, deprecation = deprecationInfo(d))))
   }
 

--- a/plugin/src/main/scala/com/typesafe/genjavadoc/JavaSig.scala
+++ b/plugin/src/main/scala/com/typesafe/genjavadoc/JavaSig.scala
@@ -178,7 +178,7 @@ trait JavaSig { this: TransformCake ⇒
   }
 
   private object NeedsSigCollector extends TypeCollector(false) {
-    def traverse(tp: Type) {
+    def traverse(tp: Type): Unit = {
       if (!result) {
         tp match {
           case st: SubType ⇒

--- a/plugin/src/test/resources/patches/2.13.0.patch
+++ b/plugin/src/test/resources/patches/2.13.0.patch
@@ -15,6 +15,15 @@
    }
    /**
     * class A.B
+@@ -76,7 +76,7 @@
+      * def b(args: java.lang.String*): Unit
+      * @param args (undocumented)
+      */
+-    public  void b (scala.collection.Seq<java.lang.String> args)  { throw new RuntimeException(); }
++    public  void b (scala.collection.immutable.Seq<java.lang.String> args)  { throw new RuntimeException(); }
+     public  java.lang.String d (java.lang.String a, akka.rk.buh.is.it.X b)  { throw new RuntimeException(); }
+   }
+   public  class C implements akka.rk.buh.is.it.X {
 @@ -94,12 +94,12 @@
      public  class C1$ {
        public   C1$ ()  { throw new RuntimeException(); }
@@ -41,7 +50,15 @@
     * varargs
     * @param s (undocumented)
     * @return (undocumented)
-@@ -219,9 +224,4 @@
+@@ -212,16 +217,11 @@
+    * @param s (undocumented)
+    * @return (undocumented)
+    */
+-  public  int hello (scala.collection.Seq<java.lang.String> s)  { throw new RuntimeException(); }
++  public  int hello (scala.collection.immutable.Seq<java.lang.String> s)  { throw new RuntimeException(); }
+   /**
+    * throws
+    * @return (undocumented)
     */
    public  int testthrows () throws java.lang.IllegalArgumentException, java.lang.NullPointerException { throw new RuntimeException(); }
    public  scala.runtime.Null$ getNull ()  { throw new RuntimeException(); }

--- a/plugin/src/test/scala/com/typesafe/genjavadoc/SignatureSpec.scala
+++ b/plugin/src/test/scala/com/typesafe/genjavadoc/SignatureSpec.scala
@@ -84,7 +84,7 @@ class SignatureSpec extends WordSpec with Matchers {
       val exception = "(akka.rk.buh.is.it.A\\$[C1D]+\\$)\\$"
       val replacemnt = "$1"
 
-      def check(jn: String) {
+      def check(jn: String): Unit = {
         val jc: Class[_] = javaCL.loadClass(jn)
         val sc: Class[_] = scalaCL.loadClass(jn.replaceAll(exception, replacemnt))
 


### PR DESCRIPTION
Disabled fatal warnings to accept the deprecation warnings for
`SortedSet.to` / `.from`. The alternative would be to use `rangeTo` /
`rangeFrom` and add the scala-collections-compat dependency.

Disabled the tests when running on 2.13, as scalacheck is not yet available.