### PR TITLE
Make JUnit more verbose

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -21,6 +21,8 @@ lazy val `genjavadoc-plugin` = (project in file("plugin"))
       "junit" % "junit" % "4.12" % Test,
       "com.novocode" % "junit-interface" % "0.11" % Test
     ),
+    // make JUnit more verbose (info print instead of debug, w/ exception names & stacktraces)
+    testOptions in Test := Seq(Tests.Argument(TestFrameworks.JUnit, "-a", "-v")),
     saveTestClasspath := {
       val result = (classDirectory in Test).value / "embeddedcp"
       IO.write(result, (fullClasspath in Test).value.map(_.data.getAbsolutePath).mkString("\n"))


### PR DESCRIPTION
Now this is output (with pretty colours):

    [info] Test run started
    [info] Test com.typesafe.genjavadoc.StrictVisibilitySpec.compileSourcesAndGenerateExpectedOutput started
    [info] Test run finished: 0 failed, 0 ignored, 1 total, 2.333s
    [info] Test run started
    [info] Test com.typesafe.genjavadoc.SignatureSpec.the$u0020generated$u0020java$u0020files$u0020contain$u0020the$u0020same$u0020methods$u0020and$u0020classes$u0020as$u0020the$u0020original$u0020Scala$u0020files started
    warning: there were three deprecation warnings (since 2.13.0); re-run with -deprecation for details
    warning: there was one feature warning; re-run with -feature for details
    [info] Test run finished: 0 failed, 0 ignored, 1 total, 2.524s
    [info] Test run started
    [info] Test com.typesafe.genjavadoc.BasicSpec.compileSourcesAndGenerateExpectedOutput started
    warning: there were three deprecation warnings (since 2.13.0); re-run with -deprecation for details
    warning: there was one feature warning; re-run with -feature for details
    patching file target/expected_output/basic/akka/rk/buh/is/it/A.java
    patching file target/expected_output/basic/akka/rk/buh/is/it/Blarb.java
    patching file target/expected_output/basic/akka/rk/buh/is/it/CompressionProtocol.java
    patching file target/expected_output/basic/akka/rk/buh/is/it/EWMA.java
    patching file target/expected_output/basic/akka/rk/buh/is/it/Trait.java
    [info] Test run finished: 0 failed, 0 ignored, 1 total, 0.964s
    [info] Passed: Total 3, Failed 0, Errors 0, Passed 3