### PR TITLE
Fix creating static forwarders for inherited methods

### DIFF
--- a/plugin/src/main/scala/com/typesafe/genjavadoc/BasicTransform.scala
+++ b/plugin/src/main/scala/com/typesafe/genjavadoc/BasicTransform.scala
@@ -17,7 +17,7 @@ trait BasicTransform { this: TransformCake ⇒
 
   def newTransformUnit(unit: CompilationUnit): Unit = {
     superTransformUnit(unit)
-    for (c ← flatten(classes.flatMap(liftInterface))) {
+    for (c ← flattenObjects(classes.flatMap(liftInterface))) {
       val out = file(c.file)
       try {
         if (c.pckg != "<empty>") out.println(s"package ${c.pckg};")

--- a/plugin/src/main/scala/com/typesafe/genjavadoc/Output.scala
+++ b/plugin/src/main/scala/com/typesafe/genjavadoc/Output.scala
@@ -184,7 +184,7 @@ trait Output { this: TransformCake ⇒
     // implements `AbstractFunctionN`, but static forwarders are not created
     // on the class for the methods on the companion object inherited from
     // that:
-    Seq("curried", "tupled")
+    Seq("curried", "tupled", "compose", "andThen")
 
   private def inheritedMethods(sym: global.Symbol, exclude: Set[String]): Seq[MethodInfo] = {
     import global._

--- a/plugin/src/test/resources/expected_output/basic/akka/actor/Identify$.java
+++ b/plugin/src/test/resources/expected_output/basic/akka/actor/Identify$.java
@@ -1,0 +1,12 @@
+package akka.actor;
+public  class Identify$ extends scala.runtime.AbstractFunction1<java.lang.Object, akka.actor.Identify> implements scala.Serializable {
+  /**
+   * Static reference to the singleton instance of this Scala object.
+   */
+  public static final Identify$ MODULE$ = null;
+  public   Identify$ ()  { throw new RuntimeException(); }
+  public final  java.lang.String toString ()  { throw new RuntimeException(); }
+  public  akka.actor.Identify apply (Object messageId)  { throw new RuntimeException(); }
+  public  scala.Option<java.lang.Object> unapply (akka.actor.Identify x$0)  { throw new RuntimeException(); }
+  private  java.lang.Object readResolve ()  { throw new RuntimeException(); }
+}

--- a/plugin/src/test/resources/expected_output/basic/akka/actor/Identify.java
+++ b/plugin/src/test/resources/expected_output/basic/akka/actor/Identify.java
@@ -1,0 +1,20 @@
+package akka.actor;
+public final class Identify implements scala.Product, scala.Serializable {
+  static public  akka.actor.Identify apply (Object messageId)  { throw new RuntimeException(); }
+  static public  scala.Option<java.lang.Object> unapply (akka.actor.Identify x$0)  { throw new RuntimeException(); }
+  static private  java.lang.Object readResolve ()  { throw new RuntimeException(); }
+  public  Object messageId ()  { throw new RuntimeException(); }
+  // not preceding
+  public   Identify (Object messageId)  { throw new RuntimeException(); }
+  public  akka.actor.Identify copy (Object messageId)  { throw new RuntimeException(); }
+  public  Object copy$default$1 ()  { throw new RuntimeException(); }
+  // not preceding
+  public  java.lang.String productPrefix ()  { throw new RuntimeException(); }
+  public  int productArity ()  { throw new RuntimeException(); }
+  public  Object productElement (int x$1)  { throw new RuntimeException(); }
+  public  scala.collection.Iterator<java.lang.Object> productIterator ()  { throw new RuntimeException(); }
+  public  boolean canEqual (Object x$1)  { throw new RuntimeException(); }
+  public  int hashCode ()  { throw new RuntimeException(); }
+  public  java.lang.String toString ()  { throw new RuntimeException(); }
+  public  boolean equals (Object x$1)  { throw new RuntimeException(); }
+}

--- a/plugin/src/test/resources/expected_output/basic/akka/actor/typed/DispatcherSelector$.java
+++ b/plugin/src/test/resources/expected_output/basic/akka/actor/typed/DispatcherSelector$.java
@@ -1,0 +1,9 @@
+package akka.actor.typed;
+public  class DispatcherSelector$ implements scala.Serializable {
+  /**
+   * Static reference to the singleton instance of this Scala object.
+   */
+  public static final DispatcherSelector$ MODULE$ = null;
+  public   DispatcherSelector$ ()  { throw new RuntimeException(); }
+  private  java.lang.Object readResolve ()  { throw new RuntimeException(); }
+}

--- a/plugin/src/test/resources/expected_output/basic/akka/actor/typed/DispatcherSelector.java
+++ b/plugin/src/test/resources/expected_output/basic/akka/actor/typed/DispatcherSelector.java
@@ -1,14 +1,5 @@
 package akka.actor.typed;
 public abstract class DispatcherSelector extends akka.actor.typed.Props {
   static private  java.lang.Object readResolve ()  { throw new RuntimeException(); }
-  static public abstract  boolean canEqual (Object that)  ;
-  static public abstract  boolean equals (Object that)  ;
-  static public abstract  Object productElement (int n)  ;
-  static public abstract  int productArity ()  ;
-  static public  scala.collection.Iterator<java.lang.Object> productIterator ()  { throw new RuntimeException(); }
-  static public  java.lang.String productPrefix ()  { throw new RuntimeException(); }
-  static public  java.lang.String productElementName (int n)  { throw new RuntimeException(); }
-  static public  scala.collection.Iterator<java.lang.String> productElementNames ()  { throw new RuntimeException(); }
-  static public abstract  akka.actor.typed.Props next ()  ;
   public   DispatcherSelector ()  { throw new RuntimeException(); }
 }

--- a/plugin/src/test/resources/expected_output/basic/akka/actor/typed/DispatcherSelector.java
+++ b/plugin/src/test/resources/expected_output/basic/akka/actor/typed/DispatcherSelector.java
@@ -1,0 +1,14 @@
+package akka.actor.typed;
+public abstract class DispatcherSelector extends akka.actor.typed.Props {
+  static private  java.lang.Object readResolve ()  { throw new RuntimeException(); }
+  static public abstract  boolean canEqual (Object that)  ;
+  static public abstract  boolean equals (Object that)  ;
+  static public abstract  Object productElement (int n)  ;
+  static public abstract  int productArity ()  ;
+  static public  scala.collection.Iterator<java.lang.Object> productIterator ()  { throw new RuntimeException(); }
+  static public  java.lang.String productPrefix ()  { throw new RuntimeException(); }
+  static public  java.lang.String productElementName (int n)  { throw new RuntimeException(); }
+  static public  scala.collection.Iterator<java.lang.String> productElementNames ()  { throw new RuntimeException(); }
+  static public abstract  akka.actor.typed.Props next ()  ;
+  public   DispatcherSelector ()  { throw new RuntimeException(); }
+}

--- a/plugin/src/test/resources/expected_output/basic/akka/actor/typed/Props.java
+++ b/plugin/src/test/resources/expected_output/basic/akka/actor/typed/Props.java
@@ -1,0 +1,5 @@
+package akka.actor.typed;
+public abstract class Props implements scala.Product, scala.Serializable {
+  public   Props ()  { throw new RuntimeException(); }
+  public abstract  akka.actor.typed.Props next ()  ;
+}

--- a/plugin/src/test/resources/input/basic/akka/actor/Actor.scala
+++ b/plugin/src/test/resources/input/basic/akka/actor/Actor.scala
@@ -1,0 +1,5 @@
+package akka.actor
+
+@SerialVersionUID(1L)
+final case class Identify(messageId: Any) // extends AutoReceivedMessage with NotInfluenceReceiveTimeout
+

--- a/plugin/src/test/resources/input/basic/akka/actor/typed/Props.scala
+++ b/plugin/src/test/resources/input/basic/akka/actor/typed/Props.scala
@@ -1,0 +1,9 @@
+package akka.actor.typed
+
+abstract class Props private[akka] () extends Product with Serializable {
+  private[akka] def next: Props
+}
+
+sealed abstract class DispatcherSelector extends Props
+
+object DispatcherSelector

--- a/plugin/src/test/resources/patches/2.12.0.patch
+++ b/plugin/src/test/resources/patches/2.12.0.patch
@@ -51,3 +51,36 @@
 -   */
 -  public  akka.rk.buh.is.it.A.D$ D ()  { throw new RuntimeException(); }
  }
+--- target/expected_output/basic/akka/actor/Identify.java
++++ target/expected_output/basic/akka/actor/Identify.java
+@@ -3,6 +3,30 @@
+   static public  akka.actor.Identify apply (Object messageId)  { throw new RuntimeException(); }
+   static public  scala.Option<java.lang.Object> unapply (akka.actor.Identify x$0)  { throw new RuntimeException(); }
+   static private  java.lang.Object readResolve ()  { throw new RuntimeException(); }
++  static public  boolean apply$mcZD$sp (double v1)  { throw new RuntimeException(); }
++  static public  double apply$mcDD$sp (double v1)  { throw new RuntimeException(); }
++  static public  float apply$mcFD$sp (double v1)  { throw new RuntimeException(); }
++  static public  int apply$mcID$sp (double v1)  { throw new RuntimeException(); }
++  static public  long apply$mcJD$sp (double v1)  { throw new RuntimeException(); }
++  static public  void apply$mcVD$sp (double v1)  { throw new RuntimeException(); }
++  static public  boolean apply$mcZF$sp (float v1)  { throw new RuntimeException(); }
++  static public  double apply$mcDF$sp (float v1)  { throw new RuntimeException(); }
++  static public  float apply$mcFF$sp (float v1)  { throw new RuntimeException(); }
++  static public  int apply$mcIF$sp (float v1)  { throw new RuntimeException(); }
++  static public  long apply$mcJF$sp (float v1)  { throw new RuntimeException(); }
++  static public  void apply$mcVF$sp (float v1)  { throw new RuntimeException(); }
++  static public  boolean apply$mcZI$sp (int v1)  { throw new RuntimeException(); }
++  static public  double apply$mcDI$sp (int v1)  { throw new RuntimeException(); }
++  static public  float apply$mcFI$sp (int v1)  { throw new RuntimeException(); }
++  static public  int apply$mcII$sp (int v1)  { throw new RuntimeException(); }
++  static public  long apply$mcJI$sp (int v1)  { throw new RuntimeException(); }
++  static public  void apply$mcVI$sp (int v1)  { throw new RuntimeException(); }
++  static public  boolean apply$mcZJ$sp (long v1)  { throw new RuntimeException(); }
++  static public  double apply$mcDJ$sp (long v1)  { throw new RuntimeException(); }
++  static public  float apply$mcFJ$sp (long v1)  { throw new RuntimeException(); }
++  static public  int apply$mcIJ$sp (long v1)  { throw new RuntimeException(); }
++  static public  long apply$mcJJ$sp (long v1)  { throw new RuntimeException(); }
++  static public  void apply$mcVJ$sp (long v1)  { throw new RuntimeException(); }
+   public  Object messageId ()  { throw new RuntimeException(); }
+   // not preceding
+   public   Identify (Object messageId)  { throw new RuntimeException(); }

--- a/plugin/src/test/resources/patches/2.12.1.patch
+++ b/plugin/src/test/resources/patches/2.12.1.patch
@@ -51,3 +51,36 @@
 -   */
 -  public  akka.rk.buh.is.it.A.D$ D ()  { throw new RuntimeException(); }
  }
+--- target/expected_output/basic/akka/actor/Identify.java
++++ target/expected_output/basic/akka/actor/Identify.java
+@@ -3,6 +3,30 @@
+   static public  akka.actor.Identify apply (Object messageId)  { throw new RuntimeException(); }
+   static public  scala.Option<java.lang.Object> unapply (akka.actor.Identify x$0)  { throw new RuntimeException(); }
+   static private  java.lang.Object readResolve ()  { throw new RuntimeException(); }
++  static public  boolean apply$mcZD$sp (double v1)  { throw new RuntimeException(); }
++  static public  double apply$mcDD$sp (double v1)  { throw new RuntimeException(); }
++  static public  float apply$mcFD$sp (double v1)  { throw new RuntimeException(); }
++  static public  int apply$mcID$sp (double v1)  { throw new RuntimeException(); }
++  static public  long apply$mcJD$sp (double v1)  { throw new RuntimeException(); }
++  static public  void apply$mcVD$sp (double v1)  { throw new RuntimeException(); }
++  static public  boolean apply$mcZF$sp (float v1)  { throw new RuntimeException(); }
++  static public  double apply$mcDF$sp (float v1)  { throw new RuntimeException(); }
++  static public  float apply$mcFF$sp (float v1)  { throw new RuntimeException(); }
++  static public  int apply$mcIF$sp (float v1)  { throw new RuntimeException(); }
++  static public  long apply$mcJF$sp (float v1)  { throw new RuntimeException(); }
++  static public  void apply$mcVF$sp (float v1)  { throw new RuntimeException(); }
++  static public  boolean apply$mcZI$sp (int v1)  { throw new RuntimeException(); }
++  static public  double apply$mcDI$sp (int v1)  { throw new RuntimeException(); }
++  static public  float apply$mcFI$sp (int v1)  { throw new RuntimeException(); }
++  static public  int apply$mcII$sp (int v1)  { throw new RuntimeException(); }
++  static public  long apply$mcJI$sp (int v1)  { throw new RuntimeException(); }
++  static public  void apply$mcVI$sp (int v1)  { throw new RuntimeException(); }
++  static public  boolean apply$mcZJ$sp (long v1)  { throw new RuntimeException(); }
++  static public  double apply$mcDJ$sp (long v1)  { throw new RuntimeException(); }
++  static public  float apply$mcFJ$sp (long v1)  { throw new RuntimeException(); }
++  static public  int apply$mcIJ$sp (long v1)  { throw new RuntimeException(); }
++  static public  long apply$mcJJ$sp (long v1)  { throw new RuntimeException(); }
++  static public  void apply$mcVJ$sp (long v1)  { throw new RuntimeException(); }
+   public  Object messageId ()  { throw new RuntimeException(); }
+   // not preceding
+   public   Identify (Object messageId)  { throw new RuntimeException(); }

--- a/plugin/src/test/resources/patches/2.12.2.patch
+++ b/plugin/src/test/resources/patches/2.12.2.patch
@@ -51,3 +51,36 @@
 -   */
 -  public  akka.rk.buh.is.it.A.D$ D ()  { throw new RuntimeException(); }
  }
+--- target/expected_output/basic/akka/actor/Identify.java
++++ target/expected_output/basic/akka/actor/Identify.java
+@@ -3,6 +3,30 @@
+   static public  akka.actor.Identify apply (Object messageId)  { throw new RuntimeException(); }
+   static public  scala.Option<java.lang.Object> unapply (akka.actor.Identify x$0)  { throw new RuntimeException(); }
+   static private  java.lang.Object readResolve ()  { throw new RuntimeException(); }
++  static public  boolean apply$mcZD$sp (double v1)  { throw new RuntimeException(); }
++  static public  double apply$mcDD$sp (double v1)  { throw new RuntimeException(); }
++  static public  float apply$mcFD$sp (double v1)  { throw new RuntimeException(); }
++  static public  int apply$mcID$sp (double v1)  { throw new RuntimeException(); }
++  static public  long apply$mcJD$sp (double v1)  { throw new RuntimeException(); }
++  static public  void apply$mcVD$sp (double v1)  { throw new RuntimeException(); }
++  static public  boolean apply$mcZF$sp (float v1)  { throw new RuntimeException(); }
++  static public  double apply$mcDF$sp (float v1)  { throw new RuntimeException(); }
++  static public  float apply$mcFF$sp (float v1)  { throw new RuntimeException(); }
++  static public  int apply$mcIF$sp (float v1)  { throw new RuntimeException(); }
++  static public  long apply$mcJF$sp (float v1)  { throw new RuntimeException(); }
++  static public  void apply$mcVF$sp (float v1)  { throw new RuntimeException(); }
++  static public  boolean apply$mcZI$sp (int v1)  { throw new RuntimeException(); }
++  static public  double apply$mcDI$sp (int v1)  { throw new RuntimeException(); }
++  static public  float apply$mcFI$sp (int v1)  { throw new RuntimeException(); }
++  static public  int apply$mcII$sp (int v1)  { throw new RuntimeException(); }
++  static public  long apply$mcJI$sp (int v1)  { throw new RuntimeException(); }
++  static public  void apply$mcVI$sp (int v1)  { throw new RuntimeException(); }
++  static public  boolean apply$mcZJ$sp (long v1)  { throw new RuntimeException(); }
++  static public  double apply$mcDJ$sp (long v1)  { throw new RuntimeException(); }
++  static public  float apply$mcFJ$sp (long v1)  { throw new RuntimeException(); }
++  static public  int apply$mcIJ$sp (long v1)  { throw new RuntimeException(); }
++  static public  long apply$mcJJ$sp (long v1)  { throw new RuntimeException(); }
++  static public  void apply$mcVJ$sp (long v1)  { throw new RuntimeException(); }
+   public  Object messageId ()  { throw new RuntimeException(); }
+   // not preceding
+   public   Identify (Object messageId)  { throw new RuntimeException(); }

--- a/plugin/src/test/resources/patches/2.12.3.patch
+++ b/plugin/src/test/resources/patches/2.12.3.patch
@@ -51,3 +51,36 @@
 -   */
 -  public  akka.rk.buh.is.it.A.D$ D ()  { throw new RuntimeException(); }
  }
+--- target/expected_output/basic/akka/actor/Identify.java
++++ target/expected_output/basic/akka/actor/Identify.java
+@@ -3,6 +3,30 @@
+   static public  akka.actor.Identify apply (Object messageId)  { throw new RuntimeException(); }
+   static public  scala.Option<java.lang.Object> unapply (akka.actor.Identify x$0)  { throw new RuntimeException(); }
+   static private  java.lang.Object readResolve ()  { throw new RuntimeException(); }
++  static public  boolean apply$mcZD$sp (double v1)  { throw new RuntimeException(); }
++  static public  double apply$mcDD$sp (double v1)  { throw new RuntimeException(); }
++  static public  float apply$mcFD$sp (double v1)  { throw new RuntimeException(); }
++  static public  int apply$mcID$sp (double v1)  { throw new RuntimeException(); }
++  static public  long apply$mcJD$sp (double v1)  { throw new RuntimeException(); }
++  static public  void apply$mcVD$sp (double v1)  { throw new RuntimeException(); }
++  static public  boolean apply$mcZF$sp (float v1)  { throw new RuntimeException(); }
++  static public  double apply$mcDF$sp (float v1)  { throw new RuntimeException(); }
++  static public  float apply$mcFF$sp (float v1)  { throw new RuntimeException(); }
++  static public  int apply$mcIF$sp (float v1)  { throw new RuntimeException(); }
++  static public  long apply$mcJF$sp (float v1)  { throw new RuntimeException(); }
++  static public  void apply$mcVF$sp (float v1)  { throw new RuntimeException(); }
++  static public  boolean apply$mcZI$sp (int v1)  { throw new RuntimeException(); }
++  static public  double apply$mcDI$sp (int v1)  { throw new RuntimeException(); }
++  static public  float apply$mcFI$sp (int v1)  { throw new RuntimeException(); }
++  static public  int apply$mcII$sp (int v1)  { throw new RuntimeException(); }
++  static public  long apply$mcJI$sp (int v1)  { throw new RuntimeException(); }
++  static public  void apply$mcVI$sp (int v1)  { throw new RuntimeException(); }
++  static public  boolean apply$mcZJ$sp (long v1)  { throw new RuntimeException(); }
++  static public  double apply$mcDJ$sp (long v1)  { throw new RuntimeException(); }
++  static public  float apply$mcFJ$sp (long v1)  { throw new RuntimeException(); }
++  static public  int apply$mcIJ$sp (long v1)  { throw new RuntimeException(); }
++  static public  long apply$mcJJ$sp (long v1)  { throw new RuntimeException(); }
++  static public  void apply$mcVJ$sp (long v1)  { throw new RuntimeException(); }
+   public  Object messageId ()  { throw new RuntimeException(); }
+   // not preceding
+   public   Identify (Object messageId)  { throw new RuntimeException(); }

--- a/plugin/src/test/resources/patches/2.12.4.patch
+++ b/plugin/src/test/resources/patches/2.12.4.patch
@@ -51,3 +51,36 @@
 -   */
 -  public  akka.rk.buh.is.it.A.D$ D ()  { throw new RuntimeException(); }
  }
+--- target/expected_output/basic/akka/actor/Identify.java
++++ target/expected_output/basic/akka/actor/Identify.java
+@@ -3,6 +3,30 @@
+   static public  akka.actor.Identify apply (Object messageId)  { throw new RuntimeException(); }
+   static public  scala.Option<java.lang.Object> unapply (akka.actor.Identify x$0)  { throw new RuntimeException(); }
+   static private  java.lang.Object readResolve ()  { throw new RuntimeException(); }
++  static public  boolean apply$mcZD$sp (double v1)  { throw new RuntimeException(); }
++  static public  double apply$mcDD$sp (double v1)  { throw new RuntimeException(); }
++  static public  float apply$mcFD$sp (double v1)  { throw new RuntimeException(); }
++  static public  int apply$mcID$sp (double v1)  { throw new RuntimeException(); }
++  static public  long apply$mcJD$sp (double v1)  { throw new RuntimeException(); }
++  static public  void apply$mcVD$sp (double v1)  { throw new RuntimeException(); }
++  static public  boolean apply$mcZF$sp (float v1)  { throw new RuntimeException(); }
++  static public  double apply$mcDF$sp (float v1)  { throw new RuntimeException(); }
++  static public  float apply$mcFF$sp (float v1)  { throw new RuntimeException(); }
++  static public  int apply$mcIF$sp (float v1)  { throw new RuntimeException(); }
++  static public  long apply$mcJF$sp (float v1)  { throw new RuntimeException(); }
++  static public  void apply$mcVF$sp (float v1)  { throw new RuntimeException(); }
++  static public  boolean apply$mcZI$sp (int v1)  { throw new RuntimeException(); }
++  static public  double apply$mcDI$sp (int v1)  { throw new RuntimeException(); }
++  static public  float apply$mcFI$sp (int v1)  { throw new RuntimeException(); }
++  static public  int apply$mcII$sp (int v1)  { throw new RuntimeException(); }
++  static public  long apply$mcJI$sp (int v1)  { throw new RuntimeException(); }
++  static public  void apply$mcVI$sp (int v1)  { throw new RuntimeException(); }
++  static public  boolean apply$mcZJ$sp (long v1)  { throw new RuntimeException(); }
++  static public  double apply$mcDJ$sp (long v1)  { throw new RuntimeException(); }
++  static public  float apply$mcFJ$sp (long v1)  { throw new RuntimeException(); }
++  static public  int apply$mcIJ$sp (long v1)  { throw new RuntimeException(); }
++  static public  long apply$mcJJ$sp (long v1)  { throw new RuntimeException(); }
++  static public  void apply$mcVJ$sp (long v1)  { throw new RuntimeException(); }
+   public  Object messageId ()  { throw new RuntimeException(); }
+   // not preceding
+   public   Identify (Object messageId)  { throw new RuntimeException(); }

--- a/plugin/src/test/resources/patches/2.12.5.patch
+++ b/plugin/src/test/resources/patches/2.12.5.patch
@@ -51,3 +51,36 @@
 -   */
 -  public  akka.rk.buh.is.it.A.D$ D ()  { throw new RuntimeException(); }
  }
+--- target/expected_output/basic/akka/actor/Identify.java
++++ target/expected_output/basic/akka/actor/Identify.java
+@@ -3,6 +3,30 @@
+   static public  akka.actor.Identify apply (Object messageId)  { throw new RuntimeException(); }
+   static public  scala.Option<java.lang.Object> unapply (akka.actor.Identify x$0)  { throw new RuntimeException(); }
+   static private  java.lang.Object readResolve ()  { throw new RuntimeException(); }
++  static public  boolean apply$mcZD$sp (double v1)  { throw new RuntimeException(); }
++  static public  double apply$mcDD$sp (double v1)  { throw new RuntimeException(); }
++  static public  float apply$mcFD$sp (double v1)  { throw new RuntimeException(); }
++  static public  int apply$mcID$sp (double v1)  { throw new RuntimeException(); }
++  static public  long apply$mcJD$sp (double v1)  { throw new RuntimeException(); }
++  static public  void apply$mcVD$sp (double v1)  { throw new RuntimeException(); }
++  static public  boolean apply$mcZF$sp (float v1)  { throw new RuntimeException(); }
++  static public  double apply$mcDF$sp (float v1)  { throw new RuntimeException(); }
++  static public  float apply$mcFF$sp (float v1)  { throw new RuntimeException(); }
++  static public  int apply$mcIF$sp (float v1)  { throw new RuntimeException(); }
++  static public  long apply$mcJF$sp (float v1)  { throw new RuntimeException(); }
++  static public  void apply$mcVF$sp (float v1)  { throw new RuntimeException(); }
++  static public  boolean apply$mcZI$sp (int v1)  { throw new RuntimeException(); }
++  static public  double apply$mcDI$sp (int v1)  { throw new RuntimeException(); }
++  static public  float apply$mcFI$sp (int v1)  { throw new RuntimeException(); }
++  static public  int apply$mcII$sp (int v1)  { throw new RuntimeException(); }
++  static public  long apply$mcJI$sp (int v1)  { throw new RuntimeException(); }
++  static public  void apply$mcVI$sp (int v1)  { throw new RuntimeException(); }
++  static public  boolean apply$mcZJ$sp (long v1)  { throw new RuntimeException(); }
++  static public  double apply$mcDJ$sp (long v1)  { throw new RuntimeException(); }
++  static public  float apply$mcFJ$sp (long v1)  { throw new RuntimeException(); }
++  static public  int apply$mcIJ$sp (long v1)  { throw new RuntimeException(); }
++  static public  long apply$mcJJ$sp (long v1)  { throw new RuntimeException(); }
++  static public  void apply$mcVJ$sp (long v1)  { throw new RuntimeException(); }
+   public  Object messageId ()  { throw new RuntimeException(); }
+   // not preceding
+   public   Identify (Object messageId)  { throw new RuntimeException(); }

--- a/plugin/src/test/resources/patches/2.12.6.patch
+++ b/plugin/src/test/resources/patches/2.12.6.patch
@@ -51,3 +51,36 @@
 -   */
 -  public  akka.rk.buh.is.it.A.D$ D ()  { throw new RuntimeException(); }
  }
+--- target/expected_output/basic/akka/actor/Identify.java
++++ target/expected_output/basic/akka/actor/Identify.java
+@@ -3,6 +3,30 @@
+   static public  akka.actor.Identify apply (Object messageId)  { throw new RuntimeException(); }
+   static public  scala.Option<java.lang.Object> unapply (akka.actor.Identify x$0)  { throw new RuntimeException(); }
+   static private  java.lang.Object readResolve ()  { throw new RuntimeException(); }
++  static public  boolean apply$mcZD$sp (double v1)  { throw new RuntimeException(); }
++  static public  double apply$mcDD$sp (double v1)  { throw new RuntimeException(); }
++  static public  float apply$mcFD$sp (double v1)  { throw new RuntimeException(); }
++  static public  int apply$mcID$sp (double v1)  { throw new RuntimeException(); }
++  static public  long apply$mcJD$sp (double v1)  { throw new RuntimeException(); }
++  static public  void apply$mcVD$sp (double v1)  { throw new RuntimeException(); }
++  static public  boolean apply$mcZF$sp (float v1)  { throw new RuntimeException(); }
++  static public  double apply$mcDF$sp (float v1)  { throw new RuntimeException(); }
++  static public  float apply$mcFF$sp (float v1)  { throw new RuntimeException(); }
++  static public  int apply$mcIF$sp (float v1)  { throw new RuntimeException(); }
++  static public  long apply$mcJF$sp (float v1)  { throw new RuntimeException(); }
++  static public  void apply$mcVF$sp (float v1)  { throw new RuntimeException(); }
++  static public  boolean apply$mcZI$sp (int v1)  { throw new RuntimeException(); }
++  static public  double apply$mcDI$sp (int v1)  { throw new RuntimeException(); }
++  static public  float apply$mcFI$sp (int v1)  { throw new RuntimeException(); }
++  static public  int apply$mcII$sp (int v1)  { throw new RuntimeException(); }
++  static public  long apply$mcJI$sp (int v1)  { throw new RuntimeException(); }
++  static public  void apply$mcVI$sp (int v1)  { throw new RuntimeException(); }
++  static public  boolean apply$mcZJ$sp (long v1)  { throw new RuntimeException(); }
++  static public  double apply$mcDJ$sp (long v1)  { throw new RuntimeException(); }
++  static public  float apply$mcFJ$sp (long v1)  { throw new RuntimeException(); }
++  static public  int apply$mcIJ$sp (long v1)  { throw new RuntimeException(); }
++  static public  long apply$mcJJ$sp (long v1)  { throw new RuntimeException(); }
++  static public  void apply$mcVJ$sp (long v1)  { throw new RuntimeException(); }
+   public  Object messageId ()  { throw new RuntimeException(); }
+   // not preceding
+   public   Identify (Object messageId)  { throw new RuntimeException(); }

--- a/plugin/src/test/resources/patches/2.12.7.patch
+++ b/plugin/src/test/resources/patches/2.12.7.patch
@@ -51,3 +51,36 @@
 -   */
 -  public  akka.rk.buh.is.it.A.D$ D ()  { throw new RuntimeException(); }
  }
+--- target/expected_output/basic/akka/actor/Identify.java
++++ target/expected_output/basic/akka/actor/Identify.java
+@@ -3,6 +3,30 @@
+   static public  akka.actor.Identify apply (Object messageId)  { throw new RuntimeException(); }
+   static public  scala.Option<java.lang.Object> unapply (akka.actor.Identify x$0)  { throw new RuntimeException(); }
+   static private  java.lang.Object readResolve ()  { throw new RuntimeException(); }
++  static public  boolean apply$mcZD$sp (double v1)  { throw new RuntimeException(); }
++  static public  double apply$mcDD$sp (double v1)  { throw new RuntimeException(); }
++  static public  float apply$mcFD$sp (double v1)  { throw new RuntimeException(); }
++  static public  int apply$mcID$sp (double v1)  { throw new RuntimeException(); }
++  static public  long apply$mcJD$sp (double v1)  { throw new RuntimeException(); }
++  static public  void apply$mcVD$sp (double v1)  { throw new RuntimeException(); }
++  static public  boolean apply$mcZF$sp (float v1)  { throw new RuntimeException(); }
++  static public  double apply$mcDF$sp (float v1)  { throw new RuntimeException(); }
++  static public  float apply$mcFF$sp (float v1)  { throw new RuntimeException(); }
++  static public  int apply$mcIF$sp (float v1)  { throw new RuntimeException(); }
++  static public  long apply$mcJF$sp (float v1)  { throw new RuntimeException(); }
++  static public  void apply$mcVF$sp (float v1)  { throw new RuntimeException(); }
++  static public  boolean apply$mcZI$sp (int v1)  { throw new RuntimeException(); }
++  static public  double apply$mcDI$sp (int v1)  { throw new RuntimeException(); }
++  static public  float apply$mcFI$sp (int v1)  { throw new RuntimeException(); }
++  static public  int apply$mcII$sp (int v1)  { throw new RuntimeException(); }
++  static public  long apply$mcJI$sp (int v1)  { throw new RuntimeException(); }
++  static public  void apply$mcVI$sp (int v1)  { throw new RuntimeException(); }
++  static public  boolean apply$mcZJ$sp (long v1)  { throw new RuntimeException(); }
++  static public  double apply$mcDJ$sp (long v1)  { throw new RuntimeException(); }
++  static public  float apply$mcFJ$sp (long v1)  { throw new RuntimeException(); }
++  static public  int apply$mcIJ$sp (long v1)  { throw new RuntimeException(); }
++  static public  long apply$mcJJ$sp (long v1)  { throw new RuntimeException(); }
++  static public  void apply$mcVJ$sp (long v1)  { throw new RuntimeException(); }
+   public  Object messageId ()  { throw new RuntimeException(); }
+   // not preceding
+   public   Identify (Object messageId)  { throw new RuntimeException(); }

--- a/plugin/src/test/resources/patches/2.12.8.patch
+++ b/plugin/src/test/resources/patches/2.12.8.patch
@@ -51,3 +51,36 @@
 -   */
 -  public  akka.rk.buh.is.it.A.D$ D ()  { throw new RuntimeException(); }
  }
+--- target/expected_output/basic/akka/actor/Identify.java
++++ target/expected_output/basic/akka/actor/Identify.java
+@@ -3,6 +3,30 @@
+   static public  akka.actor.Identify apply (Object messageId)  { throw new RuntimeException(); }
+   static public  scala.Option<java.lang.Object> unapply (akka.actor.Identify x$0)  { throw new RuntimeException(); }
+   static private  java.lang.Object readResolve ()  { throw new RuntimeException(); }
++  static public  boolean apply$mcZD$sp (double v1)  { throw new RuntimeException(); }
++  static public  double apply$mcDD$sp (double v1)  { throw new RuntimeException(); }
++  static public  float apply$mcFD$sp (double v1)  { throw new RuntimeException(); }
++  static public  int apply$mcID$sp (double v1)  { throw new RuntimeException(); }
++  static public  long apply$mcJD$sp (double v1)  { throw new RuntimeException(); }
++  static public  void apply$mcVD$sp (double v1)  { throw new RuntimeException(); }
++  static public  boolean apply$mcZF$sp (float v1)  { throw new RuntimeException(); }
++  static public  double apply$mcDF$sp (float v1)  { throw new RuntimeException(); }
++  static public  float apply$mcFF$sp (float v1)  { throw new RuntimeException(); }
++  static public  int apply$mcIF$sp (float v1)  { throw new RuntimeException(); }
++  static public  long apply$mcJF$sp (float v1)  { throw new RuntimeException(); }
++  static public  void apply$mcVF$sp (float v1)  { throw new RuntimeException(); }
++  static public  boolean apply$mcZI$sp (int v1)  { throw new RuntimeException(); }
++  static public  double apply$mcDI$sp (int v1)  { throw new RuntimeException(); }
++  static public  float apply$mcFI$sp (int v1)  { throw new RuntimeException(); }
++  static public  int apply$mcII$sp (int v1)  { throw new RuntimeException(); }
++  static public  long apply$mcJI$sp (int v1)  { throw new RuntimeException(); }
++  static public  void apply$mcVI$sp (int v1)  { throw new RuntimeException(); }
++  static public  boolean apply$mcZJ$sp (long v1)  { throw new RuntimeException(); }
++  static public  double apply$mcDJ$sp (long v1)  { throw new RuntimeException(); }
++  static public  float apply$mcFJ$sp (long v1)  { throw new RuntimeException(); }
++  static public  int apply$mcIJ$sp (long v1)  { throw new RuntimeException(); }
++  static public  long apply$mcJJ$sp (long v1)  { throw new RuntimeException(); }
++  static public  void apply$mcVJ$sp (long v1)  { throw new RuntimeException(); }
+   public  Object messageId ()  { throw new RuntimeException(); }
+   // not preceding
+   public   Identify (Object messageId)  { throw new RuntimeException(); }

--- a/plugin/src/test/resources/patches/2.12.9.patch
+++ b/plugin/src/test/resources/patches/2.12.9.patch
@@ -51,3 +51,36 @@
 -   */
 -  public  akka.rk.buh.is.it.A.D$ D ()  { throw new RuntimeException(); }
  }
+--- target/expected_output/basic/akka/actor/Identify.java
++++ target/expected_output/basic/akka/actor/Identify.java
+@@ -3,6 +3,30 @@
+   static public  akka.actor.Identify apply (Object messageId)  { throw new RuntimeException(); }
+   static public  scala.Option<java.lang.Object> unapply (akka.actor.Identify x$0)  { throw new RuntimeException(); }
+   static private  java.lang.Object readResolve ()  { throw new RuntimeException(); }
++  static public  boolean apply$mcZD$sp (double v1)  { throw new RuntimeException(); }
++  static public  double apply$mcDD$sp (double v1)  { throw new RuntimeException(); }
++  static public  float apply$mcFD$sp (double v1)  { throw new RuntimeException(); }
++  static public  int apply$mcID$sp (double v1)  { throw new RuntimeException(); }
++  static public  long apply$mcJD$sp (double v1)  { throw new RuntimeException(); }
++  static public  void apply$mcVD$sp (double v1)  { throw new RuntimeException(); }
++  static public  boolean apply$mcZF$sp (float v1)  { throw new RuntimeException(); }
++  static public  double apply$mcDF$sp (float v1)  { throw new RuntimeException(); }
++  static public  float apply$mcFF$sp (float v1)  { throw new RuntimeException(); }
++  static public  int apply$mcIF$sp (float v1)  { throw new RuntimeException(); }
++  static public  long apply$mcJF$sp (float v1)  { throw new RuntimeException(); }
++  static public  void apply$mcVF$sp (float v1)  { throw new RuntimeException(); }
++  static public  boolean apply$mcZI$sp (int v1)  { throw new RuntimeException(); }
++  static public  double apply$mcDI$sp (int v1)  { throw new RuntimeException(); }
++  static public  float apply$mcFI$sp (int v1)  { throw new RuntimeException(); }
++  static public  int apply$mcII$sp (int v1)  { throw new RuntimeException(); }
++  static public  long apply$mcJI$sp (int v1)  { throw new RuntimeException(); }
++  static public  void apply$mcVI$sp (int v1)  { throw new RuntimeException(); }
++  static public  boolean apply$mcZJ$sp (long v1)  { throw new RuntimeException(); }
++  static public  double apply$mcDJ$sp (long v1)  { throw new RuntimeException(); }
++  static public  float apply$mcFJ$sp (long v1)  { throw new RuntimeException(); }
++  static public  int apply$mcIJ$sp (long v1)  { throw new RuntimeException(); }
++  static public  long apply$mcJJ$sp (long v1)  { throw new RuntimeException(); }
++  static public  void apply$mcVJ$sp (long v1)  { throw new RuntimeException(); }
+   public  Object messageId ()  { throw new RuntimeException(); }
+   // not preceding
+   public   Identify (Object messageId)  { throw new RuntimeException(); }

--- a/plugin/src/test/resources/patches/2.13.0.patch
+++ b/plugin/src/test/resources/patches/2.13.0.patch
@@ -155,14 +155,6 @@ index b0dd497..4950950 100644
    }
 --- target/expected_output/basic/akka/rk/buh/is/it/CompressionProtocol.java
 +++ target/expected_output/basic/akka/rk/buh/is/it/CompressionProtocol.java
-@@ -9,6 +9,7 @@
-       static public  akka.rk.buh.is.it.CompressionProtocol.Events.HeavyHitterDetected apply (Object key, int id, long count)  { throw new RuntimeException(); }
-       static public  scala.Option<scala.Tuple3<java.lang.Object, java.lang.Object, java.lang.Object>> unapply (akka.rk.buh.is.it.CompressionProtocol.Events.HeavyHitterDetected x$0)  { throw new RuntimeException(); }
-       static private  java.lang.Object readResolve ()  { throw new RuntimeException(); }
-+      static public  scala.collection.Iterator<java.lang.String> productElementNames ()  { throw new RuntimeException(); }
-       public  Object key ()  { throw new RuntimeException(); }
-       public  int id ()  { throw new RuntimeException(); }
-       public  long count ()  { throw new RuntimeException(); }
 @@ -23,6 +24,7 @@
        public  java.lang.String productPrefix ()  { throw new RuntimeException(); }
        public  int productArity ()  { throw new RuntimeException(); }
@@ -173,14 +165,6 @@ index b0dd497..4950950 100644
        public  int hashCode ()  { throw new RuntimeException(); }
 --- target/expected_output/basic/akka/rk/buh/is/it/EWMA.java
 +++ target/expected_output/basic/akka/rk/buh/is/it/EWMA.java
-@@ -28,6 +28,7 @@
-   static public  akka.rk.buh.is.it.EWMA apply (double value, double alpha) { throw new RuntimeException(); }
-   static public  scala.Option<scala.Tuple2<java.lang.Object, java.lang.Object>> unapply (akka.rk.buh.is.it.EWMA x$0) { throw new RuntimeException(); }
-   static private  java.lang.Object readResolve () { throw new RuntimeException(); }
-+  static public  scala.collection.Iterator<java.lang.String> productElementNames ()  { throw new RuntimeException(); }
-   public  double value () { throw new RuntimeException(); }
-   public  double alpha () { throw new RuntimeException(); }
-   // not preceding
 @@ -48,6 +49,7 @@
    public  java.lang.String productPrefix () { throw new RuntimeException(); }
    public  int productArity () { throw new RuntimeException(); }

--- a/plugin/src/test/resources/patches/2.13.0.patch
+++ b/plugin/src/test/resources/patches/2.13.0.patch
@@ -183,3 +183,45 @@ index b0dd497..4950950 100644
      public  scala.collection.Iterator<java.lang.Object> productIterator () { throw new RuntimeException(); }
      public  boolean canEqual (Object x$1) { throw new RuntimeException(); }
      public  int hashCode () { throw new RuntimeException(); }
+--- target/expected_output/basic/akka/actor/Identify.java
++++ target/expected_output/akka/actor/Identify.java
+@@ -12,6 +12,7 @@
+   public  java.lang.String productPrefix ()  { throw new RuntimeException(); }
+   public  int productArity ()  { throw new RuntimeException(); }
+   public  Object productElement (int x$1)  { throw new RuntimeException(); }
++  public  java.lang.String productElementName (int x$1)  { throw new RuntimeException(); }
+   public  scala.collection.Iterator<java.lang.Object> productIterator ()  { throw new RuntimeException(); }
+   public  boolean canEqual (Object x$1)  { throw new RuntimeException(); }
+   public  int hashCode ()  { throw new RuntimeException(); }
+--- target/expected_output/basic/akka/actor/Identify.java
++++ target/expected_output/akka/actor/Identify.java
+@@ -3,6 +3,30 @@
+   static public  akka.actor.Identify apply (Object messageId)  { throw new RuntimeException(); }
+   static public  scala.Option<java.lang.Object> unapply (akka.actor.Identify x$0)  { throw new RuntimeException(); }
+   static private  java.lang.Object readResolve ()  { throw new RuntimeException(); }
++  static public  boolean apply$mcZD$sp (double v1)  { throw new RuntimeException(); }
++  static public  double apply$mcDD$sp (double v1)  { throw new RuntimeException(); }
++  static public  float apply$mcFD$sp (double v1)  { throw new RuntimeException(); }
++  static public  int apply$mcID$sp (double v1)  { throw new RuntimeException(); }
++  static public  long apply$mcJD$sp (double v1)  { throw new RuntimeException(); }
++  static public  void apply$mcVD$sp (double v1)  { throw new RuntimeException(); }
++  static public  boolean apply$mcZF$sp (float v1)  { throw new RuntimeException(); }
++  static public  double apply$mcDF$sp (float v1)  { throw new RuntimeException(); }
++  static public  float apply$mcFF$sp (float v1)  { throw new RuntimeException(); }
++  static public  int apply$mcIF$sp (float v1)  { throw new RuntimeException(); }
++  static public  long apply$mcJF$sp (float v1)  { throw new RuntimeException(); }
++  static public  void apply$mcVF$sp (float v1)  { throw new RuntimeException(); }
++  static public  boolean apply$mcZI$sp (int v1)  { throw new RuntimeException(); }
++  static public  double apply$mcDI$sp (int v1)  { throw new RuntimeException(); }
++  static public  float apply$mcFI$sp (int v1)  { throw new RuntimeException(); }
++  static public  int apply$mcII$sp (int v1)  { throw new RuntimeException(); }
++  static public  long apply$mcJI$sp (int v1)  { throw new RuntimeException(); }
++  static public  void apply$mcVI$sp (int v1)  { throw new RuntimeException(); }
++  static public  boolean apply$mcZJ$sp (long v1)  { throw new RuntimeException(); }
++  static public  double apply$mcDJ$sp (long v1)  { throw new RuntimeException(); }
++  static public  float apply$mcFJ$sp (long v1)  { throw new RuntimeException(); }
++  static public  int apply$mcIJ$sp (long v1)  { throw new RuntimeException(); }
++  static public  long apply$mcJJ$sp (long v1)  { throw new RuntimeException(); }
++  static public  void apply$mcVJ$sp (long v1)  { throw new RuntimeException(); }
+   public  Object messageId ()  { throw new RuntimeException(); }
+   // not preceding

--- a/plugin/src/test/scala/com/typesafe/genjavadoc/BasicSpec.scala
+++ b/plugin/src/test/scala/com/typesafe/genjavadoc/BasicSpec.scala
@@ -1,15 +1,13 @@
 package com.typesafe.genjavadoc
 
+import java.io.File
+
 import util._
 
 import scala.sys.process._
 
 object BasicSpec {
-  def sources: Seq[String] = Seq(
-    "src/test/resources/input/basic/test.scala",
-    "src/test/resources/input/basic/root.scala",
-    "src/test/resources/input/basic/akka/Main.scala"
-  )
+  def sources: Seq[String] = CompilerSpec.traverseDirectory(new File("src/test/resources/input/basic")).map(_.getAbsolutePath)
 }
 
 /** Test basic behaviour of genjavadoc with standard settings */

--- a/plugin/src/test/scala/com/typesafe/genjavadoc/StrictVisibilityTest.scala
+++ b/plugin/src/test/scala/com/typesafe/genjavadoc/StrictVisibilityTest.scala
@@ -1,11 +1,13 @@
 package com.typesafe.genjavadoc
 
+import java.io.File
+
 import util._
 
 /** Test behaviour of genjavadoc with strict visibility enabled */
 class StrictVisibilitySpec extends CompilerSpec {
 
-  override def sources = Seq("src/test/resources/input/strict_visibility/test.scala")
+  override def sources = CompilerSpec.traverseDirectory(new File("src/test/resources/input/strict_visibility")).map(_.getAbsolutePath)
   override def expectedPath: String = "src/test/resources/expected_output/strict_visibility"
   override def extraSettings = Seq("strictVisibility=true")
 

--- a/plugin/src/test/scala/com/typesafe/genjavadoc/util/CompilerSpec.scala
+++ b/plugin/src/test/scala/com/typesafe/genjavadoc/util/CompilerSpec.scala
@@ -50,3 +50,12 @@ trait CompilerSpec {
 
 
 }
+object CompilerSpec {
+  def traverseDirectory(dir: File): Seq[File] = {
+    dir.listFiles.flatMap { file: File =>
+      if (file.isFile) Seq(file)
+      else if (file.isDirectory) traverseDirectory(file)
+      else Seq.empty
+    }
+  }
+}


### PR DESCRIPTION
We should create static forwarders for the methods inherited on the
companion object, not on the class itself.

Fixes #154