### PR TITLE
Make 'appendToComment' work on C-style comments

### DIFF
--- a/plugin/src/main/scala/com/typesafe/genjavadoc/AST.scala
+++ b/plugin/src/main/scala/com/typesafe/genjavadoc/AST.scala
@@ -85,9 +85,9 @@ trait AST { this: TransformCake ⇒
     def maybeSinceDot = if (since.endsWith(".")) " " else ". "
     def render = s" * @deprecated ${msg}${maybeDot}Since $since${maybeSinceDot}"
 
-    def appendToComment(comment: Seq[String]): Seq[String] = comment match {
-      case c if c.lastOption.contains(" */") =>
-        c.init ++ List(" *", render) :+ c.last
+    def appendToComment(comment: Seq[String]): Seq[String] = comment.toList match {
+      case init :+ " */" =>
+        init ++ List(" *", render, " */")
       case c =>
         c ++ List("/**", render, "*/")
     }

--- a/plugin/src/main/scala/com/typesafe/genjavadoc/AST.scala
+++ b/plugin/src/main/scala/com/typesafe/genjavadoc/AST.scala
@@ -86,8 +86,11 @@ trait AST { this: TransformCake ⇒
     def render = s" * @deprecated ${msg}${maybeDot}Since $since${maybeSinceDot}"
 
     def appendToComment(comment: Seq[String]): Seq[String] = comment match {
-      case Nil => List("/**", render, "*/")
-      case c => c.dropRight(1) ++ List(" *", render, "*/")
+      case Nil =>
+        List("/**", render, "*/")
+      case c =>
+        if (c.lastOption.contains(" */")) c.dropRight(1) ++ List(" *", render, "*/")
+        else c ++ List("/**", render, "*/")
     }
   }
 

--- a/plugin/src/main/scala/com/typesafe/genjavadoc/AST.scala
+++ b/plugin/src/main/scala/com/typesafe/genjavadoc/AST.scala
@@ -86,11 +86,10 @@ trait AST { this: TransformCake ⇒
     def render = s" * @deprecated ${msg}${maybeDot}Since $since${maybeSinceDot}"
 
     def appendToComment(comment: Seq[String]): Seq[String] = comment match {
-      case Nil =>
-        List("/**", render, "*/")
+      case c if c.lastOption.contains(" */") =>
+        c.init ++ List(" *", render) :+ c.last
       case c =>
-        if (c.lastOption.contains(" */")) c.dropRight(1) ++ List(" *", render, "*/")
-        else c ++ List("/**", render, "*/")
+        c ++ List("/**", render, "*/")
     }
   }
 

--- a/plugin/src/main/scala/com/typesafe/genjavadoc/AST.scala
+++ b/plugin/src/main/scala/com/typesafe/genjavadoc/AST.scala
@@ -85,7 +85,7 @@ trait AST { this: TransformCake ⇒
     def maybeSinceDot = if (since.endsWith(".")) " " else ". "
     def render = s" * @deprecated ${msg}${maybeDot}Since $since${maybeSinceDot}"
 
-    def appendToComment(comment: Seq[String]): Seq[String] = comment.toList match {
+    def appendToComment(comment: Seq[String]): Seq[String] = comment.toVector match {
       case init :+ " */" =>
         init ++ List(" *", render, " */")
       case c =>

--- a/plugin/src/test/resources/expected_output/rangepos/akka/cluster/ClusterRouterGroupSettings.java
+++ b/plugin/src/test/resources/expected_output/rangepos/akka/cluster/ClusterRouterGroupSettings.java
@@ -1,0 +1,9 @@
+package akka.cluster;
+public  class ClusterRouterGroupSettings {
+  // not preceding
+  public   ClusterRouterGroupSettings ()  { throw new RuntimeException(); }
+  /**
+   * @deprecated useRole has been replaced with useRoles. Since 2.5.4.
+   */
+  public  scala.Option<java.lang.String> useRole ()  { throw new RuntimeException(); }
+}

--- a/plugin/src/test/resources/input/rangepos/akka/cluster/ClusterRouterGroupSettings.scala
+++ b/plugin/src/test/resources/input/rangepos/akka/cluster/ClusterRouterGroupSettings.scala
@@ -1,0 +1,6 @@
+package akka.cluster;
+
+class ClusterRouterGroupSettings {
+  @deprecated("useRole has been replaced with useRoles", since = "2.5.4")
+  def useRole: Option[String] = ???
+}

--- a/plugin/src/test/scala/com/typesafe/genjavadoc/RangePosSpec.scala
+++ b/plugin/src/test/scala/com/typesafe/genjavadoc/RangePosSpec.scala
@@ -1,0 +1,18 @@
+package com.typesafe.genjavadoc
+
+import java.io.File
+
+import com.typesafe.genjavadoc.util.CompilerSpec
+
+class RangePosSpec extends CompilerSpec {
+  /** Sources to compile. */
+  override def sources: Seq[String] = Seq(
+    new File("src/test/resources/input/rangepos/akka/cluster/ClusterRouterGroupSettings.scala").getAbsolutePath
+  )
+
+  override def rangepos = true
+
+  /** Root directory that contains expected Java output. */
+  override def expectedPath: String =
+    new File("src/test/resources/expected_output/rangepos").getAbsolutePath
+}

--- a/plugin/src/test/scala/com/typesafe/genjavadoc/SignatureSpec.scala
+++ b/plugin/src/test/scala/com/typesafe/genjavadoc/SignatureSpec.scala
@@ -59,7 +59,7 @@ class SignatureSpec {
     val scalac = new GenJavadocCompiler(Seq(
       s"genjavadoc:out=$docPath",
       "genjavadoc:suppressSynthetic=false"
-    ))
+    ), rangepos = false)
 
     val javaSources = expectedClasses.map{cls =>
       docPath + "/" + cls.replace(".", "/") + ".java"

--- a/plugin/src/test/scala/com/typesafe/genjavadoc/util/CompilerSpec.scala
+++ b/plugin/src/test/scala/com/typesafe/genjavadoc/util/CompilerSpec.scala
@@ -20,13 +20,16 @@ trait CompilerSpec {
   /** Extra plugin arguments. */
   def extraSettings: Seq[String] = Seq.empty
 
+  /** whether to enable -Yrangepos */
+  def rangepos: Boolean = false
+
   @Test def compileSourcesAndGenerateExpectedOutput(): Unit = {
     val doc = IO.tempDir("java")
     val docPath = doc.getAbsolutePath
     val defaultSettings = Seq(s"out=$docPath", "suppressSynthetic=false")
     val scalac = new GenJavadocCompiler((defaultSettings ++ extraSettings).map{ kv =>
       s"genjavadoc:$kv"
-    })
+    }, rangepos)
 
     scalac.compile(sources)
     assertFalse("Scala compiler reported errors", scalac.reporter.hasErrors)

--- a/plugin/src/test/scala/com/typesafe/genjavadoc/util/GenJavaDocCompiler.scala
+++ b/plugin/src/test/scala/com/typesafe/genjavadoc/util/GenJavaDocCompiler.scala
@@ -7,11 +7,14 @@ import scala.tools.nsc.reporters.ConsoleReporter
 import scala.tools.nsc.{Global, Settings}
 
 /** An instance of the Scala compiler with the genjavadoc plugin enabled
-  * @param params additional parameters to pass to the compiler
+  * @param pluginOptions additional parameters to pass to the compiler
   */
-class GenJavadocCompiler(params: Seq[String]) {
+class GenJavadocCompiler(pluginOptions: Seq[String], rangepos: Boolean) {
 
   private val settings = new Settings
+
+  settings.Yrangepos.value = rangepos
+
   val reporter = new ConsoleReporter(settings)
   private val global = new Global(settings, reporter) {
     override protected def loadRoughPluginsList() =
@@ -28,7 +31,7 @@ class GenJavadocCompiler(params: Seq[String]) {
   }
 
   settings.outputDirs.setSingleOutput(AbstractFile.getDirectory(target))
-  settings.pluginOptions.value = params.toList
+  settings.pluginOptions.value = pluginOptions.toList
 
   def compile(fileNames: Seq[String]): Unit = {
     val run = new global.Run


### PR DESCRIPTION
Previously, `appendToComment` assumed there was either no existing comment or
an existing Javadoc comment. I ran into this situation when compiling Akka with
-Yrangepos enabled (hence the test).

This change makes `appendToComment` also work when there is an existing
C-style comment.

Certainly this could be improved further, but I wanted to focus on fixing my
immediate problem.