### PR TITLE
Don't run genjavadoc while generating scaladoc

### DIFF
--- a/plugin/src/main/scala/com/typesafe/genjavadoc/Plugin.scala
+++ b/plugin/src/main/scala/com/typesafe/genjavadoc/Plugin.scala
@@ -28,7 +28,9 @@ class GenJavadocPlugin(val global: Global) extends Plugin {
 
   val name = "genjavadoc"
   val description = ""
-  val components = List[PluginComponent](MyComponent)
+  val components: List[PluginComponent] =
+    if (global.settings.isScaladoc) List.empty
+    else List(MyComponent)
 
   override def processOptions(options: List[String], error: String ⇒ Unit): Unit = {
     myOptions = new Properties()


### PR DESCRIPTION
When generating scaladoc, not the scala compiler is run with a limited set of
phases. Notably, it runs it without the 'fields' phase which genjavadoc
depends on, disabling genjavadoc while producing the warning
`dropping dependency on node with no phase object: fields`. When you have
`-Xfatal-warnings` enabled, this then leads to an error.

Inspired by https://github.com/HairyFotr/linter/issues/23