### PR TITLE
Derive POM from sbt settings

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -74,32 +74,17 @@ lazy val defaults = Seq(
     if (version.value endsWith "-SNAPSHOT") Some("snapshots" at "https://oss.sonatype.org/content/repositories/snapshots")
     else Some("releases" at "https://oss.sonatype.org/service/local/staging/deploy/maven2")
   },
-  pomExtra :=
-    (<inceptionYear>2012</inceptionYear>
-     <url>http://github.com/lightbend/genjavadoc</url>
-     <licenses>
-       <license>
-         <name>Apache 2</name>
-         <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
-         <distribution>repo</distribution>
-       </license>
-     </licenses>
-     <scm>
-       <url>git://github.com/lightbend/genjavadoc.git</url>
-       <connection>scm:git:git@github.com:lightbend/genjavadoc.git</connection>
-     </scm>) ++ makeDevelopersXml(Map(
-      "rkuhn" -> "Roland Kuhn")))
+  startYear := Some(2012),
+  homepage := Some(url("https://github.com/lightbend/genjavadoc")),
+  licenses := Seq("Apache-2.0" -> url("http://opensource.org/licenses/Apache-2.0")),
+  scmInfo := Some(ScmInfo(url("https://github.com/lightbend/genjavadoc"), "git@github.com:lightbend/genjavadoc.git")),
+  developers += Developer("contributors",
+                          "Contributors",
+                          "https://gitter.im/akka/dev",
+                          url("https://github.com/lightbend/genjavadoc/graphs/contributors"))
+)
 
 lazy val browse = SettingKey[Boolean]("browse", "run with -Ybrowse:uncurry")
-
-def makeDevelopersXml(users: Map[String, String]) =
-  <developers>
-    {
-      for ((id, user) ← users)
-        yield <developer><id>{ id }</id><name>{ user }</name></developer>
-    }
-  </developers>
-
 
 def ifJavaVersion[T](predicate: Int => Boolean)(yes: => T)(no: => T): T = {
   System.getProperty("java.version").split("\\.").toList match {

--- a/build.sbt
+++ b/build.sbt
@@ -8,10 +8,8 @@ lazy val genjavadoc = (project in file("."))
   .aggregate(`genjavadoc-plugin`)
   .settings(defaults)
   .settings(
-    publishArtifact := false,
-    git.useGitDescribe := true
+    publishArtifact := false
   )
-  .enablePlugins(GitVersioning)
 
 lazy val `genjavadoc-plugin` = (project in file("plugin"))
   .settings(defaults)

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,2 +1,2 @@
 addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.1.2")
-addSbtPlugin("com.typesafe.sbt" % "sbt-git" % "1.0.0")
+addSbtPlugin("com.dwijnand" % "sbt-dynver" % "3.3.0")


### PR DESCRIPTION
While working on #168 Sonatype rejected the generated POMs because of the duplicated SCM section. It was once added by the sbt-git plugin, and another time from the `pomExtra` in the build.sbt.

I have cleaned up the build to use sbt-dynver instead and derive the extra information for the POM from sbt settings.