### PR TITLE
GH-97 Add basic support for passing annotations to the generated Java stubs

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,36 @@ GenJavadoc can also be integrated into a Maven build (inspired by [this answer o
 </profile>
 ~~~
 
+You can integrate genjavadoc with gradle build:
+
+~~~ groovy
+apply plugin: 'scala'
+
+configurations {
+  scalaCompilerPlugin
+}
+
+dependencies {
+  // ...
+  scalaCompilerPlugin "com.typesafe.genjavadoc:genjavadoc-plugin_${scalaFullVersion}:0.13"
+  
+}
+
+tasks.withType(ScalaCompile) {
+  scalaCompileOptions.with {
+    additionalParameters = [
+        "-Xplugin:" + configurations.scalaCompilerPlugin.asPath,
+        "-P:genjavadoc:out=$buildDir/generated/java".toString()
+    ]
+  }
+}
+
+tasks.withType(Javadoc) {
+  dependsOn("compileScala")
+  source = [sourceSets.main.allJava, "$buildDir/generated/java"]
+}
+~~~
+
 ### Translation of Scaladoc comments
 
 Comments found within the Scala sources are transferred to the corresponding Java sources including some modifications. These are necessary since Scaladoc supports different mark-up elements than Javadoc. The modifications are:

--- a/plugin/src/main/scala/com/typesafe/genjavadoc/AST.scala
+++ b/plugin/src/main/scala/com/typesafe/genjavadoc/AST.scala
@@ -29,17 +29,22 @@ trait AST { this: TransformCake =>
     var firstConstructor: Boolean) extends Templ {
 
     def sig: String = {
-      s"""
-         |${addAnnotations}
-         |${pattern(name, access)}""".stripMargin
+      s"$addAnnotations${pattern(name, access)}"
     }
 
     def file = filepattern(name)
 
-    private def addAnnotations: String = sym.annotations
-      .filter(a => allowedAnnotations.contains(a.symbol.fullName('.')))
-      .map { a => s"@${a.symbol.fullName('.')}" }
-      .mkString(System.lineSeparator())
+    private def addAnnotations: String = {
+      val annotations = sym.annotations
+        .filter(a => allowedAnnotations.contains(a.symbol.fullName('.')))
+        .map { a => s"@${a.symbol.fullName('.')}" }
+        .mkString(System.lineSeparator())
+      if (!annotations.isEmpty) {
+        annotations + System.lineSeparator()
+      } else {
+        annotations
+      }
+    }
 
     def addMember(t: Templ) = copy(members = members :+ t)
 
@@ -105,16 +110,21 @@ trait AST { this: TransformCake =>
 
   case class MethodInfo(access: String, pattern: String => String, ret: String, name: String, comment: Seq[String], d: Option[DefDef] = None) extends Templ {
     def sig: String = {
-      s"""
-         |${addAnnotations}
-         |${pattern(s"$ret $name")}""".stripMargin
+      s"$addAnnotations${pattern(s"$ret $name")}"
     }
 
     private def addAnnotations: String = d match {
-      case Some(definition) => definition.symbol.annotations
-        .filter(a => allowedAnnotations.contains(a.symbol.fullName('.')))
-        .map { a => s"@${a.symbol.fullName('.')}" }
-        .mkString(System.lineSeparator())
+      case Some(definition) => {
+        val annotations = definition.symbol.annotations
+          .filter(a => allowedAnnotations.contains(a.symbol.fullName('.')))
+          .map { a => s"@${a.symbol.fullName('.')}" }
+          .mkString(System.lineSeparator())
+        if (!annotations.isEmpty) {
+          annotations + System.lineSeparator()
+        } else {
+          annotations
+        }
+      }
       case None => ""
     }
   }

--- a/plugin/src/main/scala/com/typesafe/genjavadoc/Plugin.scala
+++ b/plugin/src/main/scala/com/typesafe/genjavadoc/Plugin.scala
@@ -9,7 +9,6 @@ import java.io.File
 import java.util.Properties
 
 
-
 object GenJavadocPlugin {
 
   val javaKeywords = Set("abstract", "assert", "boolean", "break", "byte", "case", "catch", "char", "class", "const", "continue",
@@ -19,13 +18,6 @@ object GenJavadocPlugin {
     "throw", "throws", "transient", "try", "void", "volatile", "while")
 
   private val defaultFilterString = "$$"
-
-  val defaultAnnotations = Set(
-    "com.xebialabs.xlplatform.documentation.PublicApi",
-    "com.xebialabs.xlplatform.documentation.PublicApiRef",
-    "com.xebialabs.xlplatform.documentation.PublicApiMember",
-    "com.xebialabs.xlplatform.documentation.ShowOnlyPublicApiMembers"
-  ).mkString(",")
 
   def stringToFilter(s: String): Set[String] = s.split(",").toSet
 
@@ -57,11 +49,9 @@ class GenJavadocPlugin(val global: Global) extends Plugin {
   lazy val filteredStrings: Set[String] = stringToFilter(myOptions.getProperty("filter", defaultFilterString))
   lazy val fabricateParams = java.lang.Boolean.parseBoolean(myOptions.getProperty("fabricateParams", "true"))
   lazy val strictVisibility = java.lang.Boolean.parseBoolean(myOptions.getProperty("strictVisibility", "false"))
-  lazy val allowedAnnotations: Set[String] = stringToFilter(myOptions.getProperty("annotations", defaultAnnotations))
+  lazy val allowedAnnotations: Set[String] = stringToFilter(myOptions.getProperty("annotations", ""))
 
   private object MyComponent extends PluginComponent with Transform {
-
-    import global._
 
     type GT = GenJavadocPlugin.this.global.type
 

--- a/plugin/src/main/scala/com/typesafe/genjavadoc/Plugin.scala
+++ b/plugin/src/main/scala/com/typesafe/genjavadoc/Plugin.scala
@@ -53,6 +53,8 @@ class GenJavadocPlugin(val global: Global) extends Plugin {
 
   private object MyComponent extends PluginComponent with Transform {
 
+    import global._
+
     type GT = GenJavadocPlugin.this.global.type
 
     override val global: GT = GenJavadocPlugin.this.global

--- a/plugin/src/main/scala/com/typesafe/genjavadoc/Plugin.scala
+++ b/plugin/src/main/scala/com/typesafe/genjavadoc/Plugin.scala
@@ -8,6 +8,8 @@ import nsc.transform.Transform
 import java.io.File
 import java.util.Properties
 
+
+
 object GenJavadocPlugin {
 
   val javaKeywords = Set("abstract", "assert", "boolean", "break", "byte", "case", "catch", "char", "class", "const", "continue",
@@ -17,6 +19,13 @@ object GenJavadocPlugin {
     "throw", "throws", "transient", "try", "void", "volatile", "while")
 
   private val defaultFilterString = "$$"
+
+  val defaultAnnotations = Set(
+    "com.xebialabs.xlplatform.documentation.PublicApi",
+    "com.xebialabs.xlplatform.documentation.PublicApiRef",
+    "com.xebialabs.xlplatform.documentation.PublicApiMember",
+    "com.xebialabs.xlplatform.documentation.ShowOnlyPublicApiMembers"
+  ).mkString(",")
 
   def stringToFilter(s: String): Set[String] = s.split(",").toSet
 
@@ -48,6 +57,7 @@ class GenJavadocPlugin(val global: Global) extends Plugin {
   lazy val filteredStrings: Set[String] = stringToFilter(myOptions.getProperty("filter", defaultFilterString))
   lazy val fabricateParams = java.lang.Boolean.parseBoolean(myOptions.getProperty("fabricateParams", "true"))
   lazy val strictVisibility = java.lang.Boolean.parseBoolean(myOptions.getProperty("strictVisibility", "false"))
+  lazy val allowedAnnotations: Set[String] = stringToFilter(myOptions.getProperty("annotations", defaultAnnotations))
 
   private object MyComponent extends PluginComponent with Transform {
 
@@ -78,6 +88,8 @@ class GenJavadocPlugin(val global: Global) extends Plugin {
       override def transformUnit(unit: CompilationUnit) = newTransformUnit(unit)
       override def javaKeywords = GenJavadocPlugin.javaKeywords
       override def filteredStrings = GenJavadocPlugin.this.filteredStrings
+
+      override def allowedAnnotations: Set[String] = GenJavadocPlugin.this.allowedAnnotations
     }
   }
 }

--- a/plugin/src/main/scala/com/typesafe/genjavadoc/TransformCake.scala
+++ b/plugin/src/main/scala/com/typesafe/genjavadoc/TransformCake.scala
@@ -14,4 +14,6 @@ trait TransformCake extends JavaSig with Output with Comments with BasicTransfor
   def javaKeywords: Set[String]
 
   def filteredStrings: Set[String]
+
+  def allowedAnnotations: Set[String]
 }

--- a/plugin/src/test/resources/expected_output/basic/akka/WithAnnotation.java
+++ b/plugin/src/test/resources/expected_output/basic/akka/WithAnnotation.java
@@ -1,0 +1,5 @@
+package akka;
+@java.lang.SuppressWarnings
+public class WithAnnotation {
+    public WithAnnotation () { throw new RuntimeException(); }
+}

--- a/plugin/src/test/resources/input/basic/akka/WithAnnotation.scala
+++ b/plugin/src/test/resources/input/basic/akka/WithAnnotation.scala
@@ -1,0 +1,4 @@
+package akka
+
+@SuppressWarnings(value=Array(""))
+class WithAnnotation

--- a/plugin/src/test/scala/com/typesafe/genjavadoc/BasicSpec.scala
+++ b/plugin/src/test/scala/com/typesafe/genjavadoc/BasicSpec.scala
@@ -13,6 +13,7 @@ object BasicSpec {
 /** Test basic behaviour of genjavadoc with standard settings */
 class BasicSpec extends CompilerSpec {
 
+  override def extraSettings: Seq[String] = Seq("annotations=java.lang.SuppressWarnings")
   override def sources = BasicSpec.sources
   override def expectedPath: String = {
     val scalaVersion = scala.util.Properties.versionNumberString.split("-").head


### PR DESCRIPTION
Hi, we have a custom javadoc doclet that relies on some annotations to be present in Java files. In order to be able to use Scala for the code that needs to be processed with that doclet I have added very limited support that will pass annotations without any parameters to Java stubs generated by genjavadoc plugin. Can you please take a look and maybe merge it / improve it?

P.S. Are tests up-to-date? I'm not sbt user, so maybe I skipped something important but I could not get test task to pass:

```
[IJ]sbt:genjavadoc> {file:/Users/ilx/work/xebialabs/xlr-project/genjavadoc/}genjavadoc-plugin/test
[info] Updating genjavadoc-plugin...
[info] Done updating.
[info] Compiling 9 Scala sources to /Users/ilx/work/xebialabs/xlr-project/genjavadoc/plugin/target/scala-2.13.0-RC1/classes ...
[error] /Users/ilx/work/xebialabs/xlr-project/genjavadoc/plugin/src/main/scala/com/typesafe/genjavadoc/Plugin.scala:65:30: not found: type CompilationUnit
[error]     def newTransformer(unit: CompilationUnit) = new GenJavadocTransformer(unit)
[error]                              ^
[error] /Users/ilx/work/xebialabs/xlr-project/genjavadoc/plugin/src/main/scala/com/typesafe/genjavadoc/Plugin.scala:67:68: not found: type Transformer
[error]     class GenJavadocTransformer(val unit: CompilationUnit) extends Transformer with TransformCake {
[error]                                                                    ^
[error] /Users/ilx/work/xebialabs/xlr-project/genjavadoc/plugin/src/main/scala/com/typesafe/genjavadoc/Plugin.scala:67:43: not found: type CompilationUnit
[error]     class GenJavadocTransformer(val unit: CompilationUnit) extends Transformer with TransformCake {
[error]                                           ^
[error] /Users/ilx/work/xebialabs/xlr-project/genjavadoc/plugin/src/main/scala/com/typesafe/genjavadoc/Plugin.scala:65:49: type mismatch;
[error]  found   : com.typesafe.genjavadoc.GenJavadocPlugin.MyComponent.GenJavadocTransformer
[error]  required: com.typesafe.genjavadoc.GenJavadocPlugin.MyComponent.global.Transformer
[error]     def newTransformer(unit: CompilationUnit) = new GenJavadocTransformer(unit)
```

