### PR TITLE
Set compiler phase `runsBefore` to `tailcalls`

### DIFF
--- a/plugin/src/main/scala/com/typesafe/genjavadoc/Plugin.scala
+++ b/plugin/src/main/scala/com/typesafe/genjavadoc/Plugin.scala
@@ -61,9 +61,9 @@ class GenJavadocPlugin(val global: Global) extends Plugin {
 
     override val global: GT = GenJavadocPlugin.this.global
 
-    val isPreFields =
-      nsc.Properties.versionNumberString.startsWith("2.11.")
-    override val runsAfter = List(if(isPreFields) "uncurry" else "fields")
+  val isPreFields = nsc.Properties.versionNumberString.startsWith("2.11.")
+   override val runsAfter = List(if (isPreFields) "uncurry" else "fields")
+   override val runsBefore: List[String] = List("tailcalls")
     val phaseName = "GenJavadoc"
 
     def newTransformer(unit: CompilationUnit) = new GenJavadocTransformer(unit)

--- a/plugin/src/test/resources/expected_output/basic/akka/rk/buh/is/it/A.java
+++ b/plugin/src/test/resources/expected_output/basic/akka/rk/buh/is/it/A.java
@@ -84,6 +84,11 @@ public  class A {
     public   C ()  { throw new RuntimeException(); }
     public  int i ()  { throw new RuntimeException(); }
   }
+  /** tailrecced */
+  public final class TR {
+    public   TR ()  { throw new RuntimeException(); }
+    public  void tr (java.lang.String r)  { throw new RuntimeException(); }
+  }
   /**
    * object A.C.C1
    */

--- a/plugin/src/test/resources/input/basic/test.scala
+++ b/plugin/src/test/resources/input/basic/test.scala
@@ -183,6 +183,14 @@ class A {
      */
     object E
   }
+
+  /** tailrecced */
+  final class TR {
+    @scala.annotation.tailrec def tr(r: String): Unit = r match {
+      case _ => tr(r)
+    }
+  }
+
 }
 
 /**

--- a/plugin/src/test/resources/patches/2.12.0.patch
+++ b/plugin/src/test/resources/patches/2.12.0.patch
@@ -47,39 +47,6 @@
 -   */
 -  public  akka.rk.buh.is.it.A.D$ D ()  { throw new RuntimeException(); }
  }
---- target/expected_output/basic/akka/actor/Identify.java
-+++ target/expected_output/basic/akka/actor/Identify.java
-@@ -2,6 +2,30 @@
- public final class Identify implements scala.Product, scala.Serializable {
-   static public  akka.actor.Identify apply (Object messageId)  { throw new RuntimeException(); }
-   static public  scala.Option<java.lang.Object> unapply (akka.actor.Identify x$0)  { throw new RuntimeException(); }
-+  static public  boolean apply$mcZD$sp (double v1)  { throw new RuntimeException(); }
-+  static public  double apply$mcDD$sp (double v1)  { throw new RuntimeException(); }
-+  static public  float apply$mcFD$sp (double v1)  { throw new RuntimeException(); }
-+  static public  int apply$mcID$sp (double v1)  { throw new RuntimeException(); }
-+  static public  long apply$mcJD$sp (double v1)  { throw new RuntimeException(); }
-+  static public  void apply$mcVD$sp (double v1)  { throw new RuntimeException(); }
-+  static public  boolean apply$mcZF$sp (float v1)  { throw new RuntimeException(); }
-+  static public  double apply$mcDF$sp (float v1)  { throw new RuntimeException(); }
-+  static public  float apply$mcFF$sp (float v1)  { throw new RuntimeException(); }
-+  static public  int apply$mcIF$sp (float v1)  { throw new RuntimeException(); }
-+  static public  long apply$mcJF$sp (float v1)  { throw new RuntimeException(); }
-+  static public  void apply$mcVF$sp (float v1)  { throw new RuntimeException(); }
-+  static public  boolean apply$mcZI$sp (int v1)  { throw new RuntimeException(); }
-+  static public  double apply$mcDI$sp (int v1)  { throw new RuntimeException(); }
-+  static public  float apply$mcFI$sp (int v1)  { throw new RuntimeException(); }
-+  static public  int apply$mcII$sp (int v1)  { throw new RuntimeException(); }
-+  static public  long apply$mcJI$sp (int v1)  { throw new RuntimeException(); }
-+  static public  void apply$mcVI$sp (int v1)  { throw new RuntimeException(); }
-+  static public  boolean apply$mcZJ$sp (long v1)  { throw new RuntimeException(); }
-+  static public  double apply$mcDJ$sp (long v1)  { throw new RuntimeException(); }
-+  static public  float apply$mcFJ$sp (long v1)  { throw new RuntimeException(); }
-+  static public  int apply$mcIJ$sp (long v1)  { throw new RuntimeException(); }
-+  static public  long apply$mcJJ$sp (long v1)  { throw new RuntimeException(); }
-+  static public  void apply$mcVJ$sp (long v1)  { throw new RuntimeException(); }
-   public  Object messageId ()  { throw new RuntimeException(); }
-   // not preceding
-   public   Identify (Object messageId)  { throw new RuntimeException(); }
 --- target/expected_output/basic/akka/actor/dsl/Inbox.java    2018-12-13 15:51:52.473679518 +0100
 +++ target/expected_output/basic/akka/actor/dsl/Inbox.java 2018-12-13 15:51:51.473673128 +0100
 @@ -2,5 +2,6 @@

--- a/plugin/src/test/resources/patches/2.12.0.patch
+++ b/plugin/src/test/resources/patches/2.12.0.patch
@@ -15,7 +15,7 @@
    }
    /**
     * class A.B
-@@ -98,8 +98,8 @@
+@@ -103,8 +103,8 @@
     * class A.C
     */
    static public  class C1 {
@@ -25,7 +25,7 @@
    }
    /**
     * object C1
-@@ -137,6 +137,11 @@
+@@ -142,6 +142,11 @@
    static public  java.lang.String stattic ()  { throw new RuntimeException(); }
    static public  java.lang.Object x ()  { throw new RuntimeException(); }
    /**
@@ -37,7 +37,7 @@
     * varargs
     * @param s (undocumented)
     * @return (undocumented)
-@@ -209,9 +214,4 @@
+@@ -214,9 +219,4 @@
     */
    public  int testthrows () throws java.lang.IllegalArgumentException, java.lang.NullPointerException { throw new RuntimeException(); }
    public  scala.runtime.Null$ getNull ()  { throw new RuntimeException(); }
@@ -47,6 +47,39 @@
 -   */
 -  public  akka.rk.buh.is.it.A.D$ D ()  { throw new RuntimeException(); }
  }
+--- target/expected_output/basic/akka/actor/Identify.java
++++ target/expected_output/basic/akka/actor/Identify.java
+@@ -2,6 +2,30 @@
+ public final class Identify implements scala.Product, scala.Serializable {
+   static public  akka.actor.Identify apply (Object messageId)  { throw new RuntimeException(); }
+   static public  scala.Option<java.lang.Object> unapply (akka.actor.Identify x$0)  { throw new RuntimeException(); }
++  static public  boolean apply$mcZD$sp (double v1)  { throw new RuntimeException(); }
++  static public  double apply$mcDD$sp (double v1)  { throw new RuntimeException(); }
++  static public  float apply$mcFD$sp (double v1)  { throw new RuntimeException(); }
++  static public  int apply$mcID$sp (double v1)  { throw new RuntimeException(); }
++  static public  long apply$mcJD$sp (double v1)  { throw new RuntimeException(); }
++  static public  void apply$mcVD$sp (double v1)  { throw new RuntimeException(); }
++  static public  boolean apply$mcZF$sp (float v1)  { throw new RuntimeException(); }
++  static public  double apply$mcDF$sp (float v1)  { throw new RuntimeException(); }
++  static public  float apply$mcFF$sp (float v1)  { throw new RuntimeException(); }
++  static public  int apply$mcIF$sp (float v1)  { throw new RuntimeException(); }
++  static public  long apply$mcJF$sp (float v1)  { throw new RuntimeException(); }
++  static public  void apply$mcVF$sp (float v1)  { throw new RuntimeException(); }
++  static public  boolean apply$mcZI$sp (int v1)  { throw new RuntimeException(); }
++  static public  double apply$mcDI$sp (int v1)  { throw new RuntimeException(); }
++  static public  float apply$mcFI$sp (int v1)  { throw new RuntimeException(); }
++  static public  int apply$mcII$sp (int v1)  { throw new RuntimeException(); }
++  static public  long apply$mcJI$sp (int v1)  { throw new RuntimeException(); }
++  static public  void apply$mcVI$sp (int v1)  { throw new RuntimeException(); }
++  static public  boolean apply$mcZJ$sp (long v1)  { throw new RuntimeException(); }
++  static public  double apply$mcDJ$sp (long v1)  { throw new RuntimeException(); }
++  static public  float apply$mcFJ$sp (long v1)  { throw new RuntimeException(); }
++  static public  int apply$mcIJ$sp (long v1)  { throw new RuntimeException(); }
++  static public  long apply$mcJJ$sp (long v1)  { throw new RuntimeException(); }
++  static public  void apply$mcVJ$sp (long v1)  { throw new RuntimeException(); }
+   public  Object messageId ()  { throw new RuntimeException(); }
+   // not preceding
+   public   Identify (Object messageId)  { throw new RuntimeException(); }
 --- target/expected_output/basic/akka/actor/dsl/Inbox.java    2018-12-13 15:51:52.473679518 +0100
 +++ target/expected_output/basic/akka/actor/dsl/Inbox.java 2018-12-13 15:51:51.473673128 +0100
 @@ -2,5 +2,6 @@

--- a/plugin/src/test/resources/patches/2.12.1.patch
+++ b/plugin/src/test/resources/patches/2.12.1.patch
@@ -47,39 +47,6 @@
 -   */
 -  public  akka.rk.buh.is.it.A.D$ D ()  { throw new RuntimeException(); }
  }
---- target/expected_output/basic/akka/actor/Identify.java
-+++ target/expected_output/basic/akka/actor/Identify.java
-@@ -2,6 +2,30 @@
- public final class Identify implements scala.Product, scala.Serializable {
-   static public  akka.actor.Identify apply (Object messageId)  { throw new RuntimeException(); }
-   static public  scala.Option<java.lang.Object> unapply (akka.actor.Identify x$0)  { throw new RuntimeException(); }
-+  static public  boolean apply$mcZD$sp (double v1)  { throw new RuntimeException(); }
-+  static public  double apply$mcDD$sp (double v1)  { throw new RuntimeException(); }
-+  static public  float apply$mcFD$sp (double v1)  { throw new RuntimeException(); }
-+  static public  int apply$mcID$sp (double v1)  { throw new RuntimeException(); }
-+  static public  long apply$mcJD$sp (double v1)  { throw new RuntimeException(); }
-+  static public  void apply$mcVD$sp (double v1)  { throw new RuntimeException(); }
-+  static public  boolean apply$mcZF$sp (float v1)  { throw new RuntimeException(); }
-+  static public  double apply$mcDF$sp (float v1)  { throw new RuntimeException(); }
-+  static public  float apply$mcFF$sp (float v1)  { throw new RuntimeException(); }
-+  static public  int apply$mcIF$sp (float v1)  { throw new RuntimeException(); }
-+  static public  long apply$mcJF$sp (float v1)  { throw new RuntimeException(); }
-+  static public  void apply$mcVF$sp (float v1)  { throw new RuntimeException(); }
-+  static public  boolean apply$mcZI$sp (int v1)  { throw new RuntimeException(); }
-+  static public  double apply$mcDI$sp (int v1)  { throw new RuntimeException(); }
-+  static public  float apply$mcFI$sp (int v1)  { throw new RuntimeException(); }
-+  static public  int apply$mcII$sp (int v1)  { throw new RuntimeException(); }
-+  static public  long apply$mcJI$sp (int v1)  { throw new RuntimeException(); }
-+  static public  void apply$mcVI$sp (int v1)  { throw new RuntimeException(); }
-+  static public  boolean apply$mcZJ$sp (long v1)  { throw new RuntimeException(); }
-+  static public  double apply$mcDJ$sp (long v1)  { throw new RuntimeException(); }
-+  static public  float apply$mcFJ$sp (long v1)  { throw new RuntimeException(); }
-+  static public  int apply$mcIJ$sp (long v1)  { throw new RuntimeException(); }
-+  static public  long apply$mcJJ$sp (long v1)  { throw new RuntimeException(); }
-+  static public  void apply$mcVJ$sp (long v1)  { throw new RuntimeException(); }
-   public  Object messageId ()  { throw new RuntimeException(); }
-   // not preceding
-   public   Identify (Object messageId)  { throw new RuntimeException(); }
 --- target/expected_output/basic/akka/actor/dsl/Inbox.java    2018-12-13 15:51:52.473679518 +0100
 +++ target/expected_output/basic/akka/actor/dsl/Inbox.java 2018-12-13 15:51:51.473673128 +0100
 @@ -2,5 +2,6 @@

--- a/plugin/src/test/resources/patches/2.12.1.patch
+++ b/plugin/src/test/resources/patches/2.12.1.patch
@@ -15,7 +15,7 @@
    }
    /**
     * class A.B
-@@ -98,8 +98,8 @@
+@@ -103,8 +103,8 @@
     * class A.C
     */
    static public  class C1 {
@@ -25,7 +25,7 @@
    }
    /**
     * object C1
-@@ -137,6 +137,11 @@
+@@ -142,6 +142,11 @@
    static public  java.lang.String stattic ()  { throw new RuntimeException(); }
    static public  java.lang.Object x ()  { throw new RuntimeException(); }
    /**
@@ -37,7 +37,7 @@
     * varargs
     * @param s (undocumented)
     * @return (undocumented)
-@@ -209,9 +214,4 @@
+@@ -214,9 +219,4 @@
     */
    public  int testthrows () throws java.lang.IllegalArgumentException, java.lang.NullPointerException { throw new RuntimeException(); }
    public  scala.runtime.Null$ getNull ()  { throw new RuntimeException(); }
@@ -47,6 +47,39 @@
 -   */
 -  public  akka.rk.buh.is.it.A.D$ D ()  { throw new RuntimeException(); }
  }
+--- target/expected_output/basic/akka/actor/Identify.java
++++ target/expected_output/basic/akka/actor/Identify.java
+@@ -2,6 +2,30 @@
+ public final class Identify implements scala.Product, scala.Serializable {
+   static public  akka.actor.Identify apply (Object messageId)  { throw new RuntimeException(); }
+   static public  scala.Option<java.lang.Object> unapply (akka.actor.Identify x$0)  { throw new RuntimeException(); }
++  static public  boolean apply$mcZD$sp (double v1)  { throw new RuntimeException(); }
++  static public  double apply$mcDD$sp (double v1)  { throw new RuntimeException(); }
++  static public  float apply$mcFD$sp (double v1)  { throw new RuntimeException(); }
++  static public  int apply$mcID$sp (double v1)  { throw new RuntimeException(); }
++  static public  long apply$mcJD$sp (double v1)  { throw new RuntimeException(); }
++  static public  void apply$mcVD$sp (double v1)  { throw new RuntimeException(); }
++  static public  boolean apply$mcZF$sp (float v1)  { throw new RuntimeException(); }
++  static public  double apply$mcDF$sp (float v1)  { throw new RuntimeException(); }
++  static public  float apply$mcFF$sp (float v1)  { throw new RuntimeException(); }
++  static public  int apply$mcIF$sp (float v1)  { throw new RuntimeException(); }
++  static public  long apply$mcJF$sp (float v1)  { throw new RuntimeException(); }
++  static public  void apply$mcVF$sp (float v1)  { throw new RuntimeException(); }
++  static public  boolean apply$mcZI$sp (int v1)  { throw new RuntimeException(); }
++  static public  double apply$mcDI$sp (int v1)  { throw new RuntimeException(); }
++  static public  float apply$mcFI$sp (int v1)  { throw new RuntimeException(); }
++  static public  int apply$mcII$sp (int v1)  { throw new RuntimeException(); }
++  static public  long apply$mcJI$sp (int v1)  { throw new RuntimeException(); }
++  static public  void apply$mcVI$sp (int v1)  { throw new RuntimeException(); }
++  static public  boolean apply$mcZJ$sp (long v1)  { throw new RuntimeException(); }
++  static public  double apply$mcDJ$sp (long v1)  { throw new RuntimeException(); }
++  static public  float apply$mcFJ$sp (long v1)  { throw new RuntimeException(); }
++  static public  int apply$mcIJ$sp (long v1)  { throw new RuntimeException(); }
++  static public  long apply$mcJJ$sp (long v1)  { throw new RuntimeException(); }
++  static public  void apply$mcVJ$sp (long v1)  { throw new RuntimeException(); }
+   public  Object messageId ()  { throw new RuntimeException(); }
+   // not preceding
+   public   Identify (Object messageId)  { throw new RuntimeException(); }
 --- target/expected_output/basic/akka/actor/dsl/Inbox.java    2018-12-13 15:51:52.473679518 +0100
 +++ target/expected_output/basic/akka/actor/dsl/Inbox.java 2018-12-13 15:51:51.473673128 +0100
 @@ -2,5 +2,6 @@

--- a/plugin/src/test/resources/patches/2.12.10.patch
+++ b/plugin/src/test/resources/patches/2.12.10.patch
@@ -15,7 +15,7 @@
    }
    /**
     * class A.B
-@@ -98,8 +98,8 @@
+@@ -103,8 +103,8 @@
     * class A.C
     */
    static public  class C1 {
@@ -25,7 +25,7 @@
    }
    /**
     * object C1
-@@ -137,6 +137,11 @@
+@@ -142,6 +142,11 @@
    static public  java.lang.String stattic ()  { throw new RuntimeException(); }
    static public  java.lang.Object x ()  { throw new RuntimeException(); }
    /**
@@ -37,7 +37,7 @@
     * varargs
     * @param s (undocumented)
     * @return (undocumented)
-@@ -209,9 +214,4 @@
+@@ -214,9 +219,4 @@
     */
    public  int testthrows () throws java.lang.IllegalArgumentException, java.lang.NullPointerException { throw new RuntimeException(); }
    public  scala.runtime.Null$ getNull ()  { throw new RuntimeException(); }

--- a/plugin/src/test/resources/patches/2.12.11.patch
+++ b/plugin/src/test/resources/patches/2.12.11.patch
@@ -15,7 +15,7 @@
    }
    /**
     * class A.B
-@@ -98,8 +98,8 @@
+@@ -103,8 +103,8 @@
     * class A.C
     */
    static public  class C1 {
@@ -25,7 +25,7 @@
    }
    /**
     * object C1
-@@ -137,6 +137,11 @@
+@@ -142,6 +142,11 @@
    static public  java.lang.String stattic ()  { throw new RuntimeException(); }
    static public  java.lang.Object x ()  { throw new RuntimeException(); }
    /**
@@ -37,7 +37,7 @@
     * varargs
     * @param s (undocumented)
     * @return (undocumented)
-@@ -209,9 +214,4 @@
+@@ -214,9 +219,4 @@
     */
    public  int testthrows () throws java.lang.IllegalArgumentException, java.lang.NullPointerException { throw new RuntimeException(); }
    public  scala.runtime.Null$ getNull ()  { throw new RuntimeException(); }

--- a/plugin/src/test/resources/patches/2.12.2.patch
+++ b/plugin/src/test/resources/patches/2.12.2.patch
@@ -47,39 +47,6 @@
 -   */
 -  public  akka.rk.buh.is.it.A.D$ D ()  { throw new RuntimeException(); }
  }
---- target/expected_output/basic/akka/actor/Identify.java
-+++ target/expected_output/basic/akka/actor/Identify.java
-@@ -2,6 +2,30 @@
- public final class Identify implements scala.Product, scala.Serializable {
-   static public  akka.actor.Identify apply (Object messageId)  { throw new RuntimeException(); }
-   static public  scala.Option<java.lang.Object> unapply (akka.actor.Identify x$0)  { throw new RuntimeException(); }
-+  static public  boolean apply$mcZD$sp (double v1)  { throw new RuntimeException(); }
-+  static public  double apply$mcDD$sp (double v1)  { throw new RuntimeException(); }
-+  static public  float apply$mcFD$sp (double v1)  { throw new RuntimeException(); }
-+  static public  int apply$mcID$sp (double v1)  { throw new RuntimeException(); }
-+  static public  long apply$mcJD$sp (double v1)  { throw new RuntimeException(); }
-+  static public  void apply$mcVD$sp (double v1)  { throw new RuntimeException(); }
-+  static public  boolean apply$mcZF$sp (float v1)  { throw new RuntimeException(); }
-+  static public  double apply$mcDF$sp (float v1)  { throw new RuntimeException(); }
-+  static public  float apply$mcFF$sp (float v1)  { throw new RuntimeException(); }
-+  static public  int apply$mcIF$sp (float v1)  { throw new RuntimeException(); }
-+  static public  long apply$mcJF$sp (float v1)  { throw new RuntimeException(); }
-+  static public  void apply$mcVF$sp (float v1)  { throw new RuntimeException(); }
-+  static public  boolean apply$mcZI$sp (int v1)  { throw new RuntimeException(); }
-+  static public  double apply$mcDI$sp (int v1)  { throw new RuntimeException(); }
-+  static public  float apply$mcFI$sp (int v1)  { throw new RuntimeException(); }
-+  static public  int apply$mcII$sp (int v1)  { throw new RuntimeException(); }
-+  static public  long apply$mcJI$sp (int v1)  { throw new RuntimeException(); }
-+  static public  void apply$mcVI$sp (int v1)  { throw new RuntimeException(); }
-+  static public  boolean apply$mcZJ$sp (long v1)  { throw new RuntimeException(); }
-+  static public  double apply$mcDJ$sp (long v1)  { throw new RuntimeException(); }
-+  static public  float apply$mcFJ$sp (long v1)  { throw new RuntimeException(); }
-+  static public  int apply$mcIJ$sp (long v1)  { throw new RuntimeException(); }
-+  static public  long apply$mcJJ$sp (long v1)  { throw new RuntimeException(); }
-+  static public  void apply$mcVJ$sp (long v1)  { throw new RuntimeException(); }
-   public  Object messageId ()  { throw new RuntimeException(); }
-   // not preceding
-   public   Identify (Object messageId)  { throw new RuntimeException(); }
 --- target/expected_output/basic/akka/actor/dsl/Inbox.java    2018-12-13 15:51:52.473679518 +0100
 +++ target/expected_output/basic/akka/actor/dsl/Inbox.java 2018-12-13 15:51:51.473673128 +0100
 @@ -2,5 +2,6 @@

--- a/plugin/src/test/resources/patches/2.12.2.patch
+++ b/plugin/src/test/resources/patches/2.12.2.patch
@@ -15,7 +15,7 @@
    }
    /**
     * class A.B
-@@ -98,8 +98,8 @@
+@@ -103,8 +103,8 @@
     * class A.C
     */
    static public  class C1 {
@@ -25,7 +25,7 @@
    }
    /**
     * object C1
-@@ -137,6 +137,11 @@
+@@ -142,6 +142,11 @@
    static public  java.lang.String stattic ()  { throw new RuntimeException(); }
    static public  java.lang.Object x ()  { throw new RuntimeException(); }
    /**
@@ -37,7 +37,7 @@
     * varargs
     * @param s (undocumented)
     * @return (undocumented)
-@@ -209,9 +214,4 @@
+@@ -214,9 +219,4 @@
     */
    public  int testthrows () throws java.lang.IllegalArgumentException, java.lang.NullPointerException { throw new RuntimeException(); }
    public  scala.runtime.Null$ getNull ()  { throw new RuntimeException(); }
@@ -47,6 +47,39 @@
 -   */
 -  public  akka.rk.buh.is.it.A.D$ D ()  { throw new RuntimeException(); }
  }
+--- target/expected_output/basic/akka/actor/Identify.java
++++ target/expected_output/basic/akka/actor/Identify.java
+@@ -2,6 +2,30 @@
+ public final class Identify implements scala.Product, scala.Serializable {
+   static public  akka.actor.Identify apply (Object messageId)  { throw new RuntimeException(); }
+   static public  scala.Option<java.lang.Object> unapply (akka.actor.Identify x$0)  { throw new RuntimeException(); }
++  static public  boolean apply$mcZD$sp (double v1)  { throw new RuntimeException(); }
++  static public  double apply$mcDD$sp (double v1)  { throw new RuntimeException(); }
++  static public  float apply$mcFD$sp (double v1)  { throw new RuntimeException(); }
++  static public  int apply$mcID$sp (double v1)  { throw new RuntimeException(); }
++  static public  long apply$mcJD$sp (double v1)  { throw new RuntimeException(); }
++  static public  void apply$mcVD$sp (double v1)  { throw new RuntimeException(); }
++  static public  boolean apply$mcZF$sp (float v1)  { throw new RuntimeException(); }
++  static public  double apply$mcDF$sp (float v1)  { throw new RuntimeException(); }
++  static public  float apply$mcFF$sp (float v1)  { throw new RuntimeException(); }
++  static public  int apply$mcIF$sp (float v1)  { throw new RuntimeException(); }
++  static public  long apply$mcJF$sp (float v1)  { throw new RuntimeException(); }
++  static public  void apply$mcVF$sp (float v1)  { throw new RuntimeException(); }
++  static public  boolean apply$mcZI$sp (int v1)  { throw new RuntimeException(); }
++  static public  double apply$mcDI$sp (int v1)  { throw new RuntimeException(); }
++  static public  float apply$mcFI$sp (int v1)  { throw new RuntimeException(); }
++  static public  int apply$mcII$sp (int v1)  { throw new RuntimeException(); }
++  static public  long apply$mcJI$sp (int v1)  { throw new RuntimeException(); }
++  static public  void apply$mcVI$sp (int v1)  { throw new RuntimeException(); }
++  static public  boolean apply$mcZJ$sp (long v1)  { throw new RuntimeException(); }
++  static public  double apply$mcDJ$sp (long v1)  { throw new RuntimeException(); }
++  static public  float apply$mcFJ$sp (long v1)  { throw new RuntimeException(); }
++  static public  int apply$mcIJ$sp (long v1)  { throw new RuntimeException(); }
++  static public  long apply$mcJJ$sp (long v1)  { throw new RuntimeException(); }
++  static public  void apply$mcVJ$sp (long v1)  { throw new RuntimeException(); }
+   public  Object messageId ()  { throw new RuntimeException(); }
+   // not preceding
+   public   Identify (Object messageId)  { throw new RuntimeException(); }
 --- target/expected_output/basic/akka/actor/dsl/Inbox.java    2018-12-13 15:51:52.473679518 +0100
 +++ target/expected_output/basic/akka/actor/dsl/Inbox.java 2018-12-13 15:51:51.473673128 +0100
 @@ -2,5 +2,6 @@

--- a/plugin/src/test/resources/patches/2.12.3.patch
+++ b/plugin/src/test/resources/patches/2.12.3.patch
@@ -47,39 +47,6 @@
 -   */
 -  public  akka.rk.buh.is.it.A.D$ D ()  { throw new RuntimeException(); }
  }
---- target/expected_output/basic/akka/actor/Identify.java
-+++ target/expected_output/basic/akka/actor/Identify.java
-@@ -2,6 +2,30 @@
- public final class Identify implements scala.Product, scala.Serializable {
-   static public  akka.actor.Identify apply (Object messageId)  { throw new RuntimeException(); }
-   static public  scala.Option<java.lang.Object> unapply (akka.actor.Identify x$0)  { throw new RuntimeException(); }
-+  static public  boolean apply$mcZD$sp (double v1)  { throw new RuntimeException(); }
-+  static public  double apply$mcDD$sp (double v1)  { throw new RuntimeException(); }
-+  static public  float apply$mcFD$sp (double v1)  { throw new RuntimeException(); }
-+  static public  int apply$mcID$sp (double v1)  { throw new RuntimeException(); }
-+  static public  long apply$mcJD$sp (double v1)  { throw new RuntimeException(); }
-+  static public  void apply$mcVD$sp (double v1)  { throw new RuntimeException(); }
-+  static public  boolean apply$mcZF$sp (float v1)  { throw new RuntimeException(); }
-+  static public  double apply$mcDF$sp (float v1)  { throw new RuntimeException(); }
-+  static public  float apply$mcFF$sp (float v1)  { throw new RuntimeException(); }
-+  static public  int apply$mcIF$sp (float v1)  { throw new RuntimeException(); }
-+  static public  long apply$mcJF$sp (float v1)  { throw new RuntimeException(); }
-+  static public  void apply$mcVF$sp (float v1)  { throw new RuntimeException(); }
-+  static public  boolean apply$mcZI$sp (int v1)  { throw new RuntimeException(); }
-+  static public  double apply$mcDI$sp (int v1)  { throw new RuntimeException(); }
-+  static public  float apply$mcFI$sp (int v1)  { throw new RuntimeException(); }
-+  static public  int apply$mcII$sp (int v1)  { throw new RuntimeException(); }
-+  static public  long apply$mcJI$sp (int v1)  { throw new RuntimeException(); }
-+  static public  void apply$mcVI$sp (int v1)  { throw new RuntimeException(); }
-+  static public  boolean apply$mcZJ$sp (long v1)  { throw new RuntimeException(); }
-+  static public  double apply$mcDJ$sp (long v1)  { throw new RuntimeException(); }
-+  static public  float apply$mcFJ$sp (long v1)  { throw new RuntimeException(); }
-+  static public  int apply$mcIJ$sp (long v1)  { throw new RuntimeException(); }
-+  static public  long apply$mcJJ$sp (long v1)  { throw new RuntimeException(); }
-+  static public  void apply$mcVJ$sp (long v1)  { throw new RuntimeException(); }
-   public  Object messageId ()  { throw new RuntimeException(); }
-   // not preceding
-   public   Identify (Object messageId)  { throw new RuntimeException(); }
 --- target/expected_output/basic/akka/actor/dsl/Inbox.java    2018-12-13 15:51:52.473679518 +0100
 +++ target/expected_output/basic/akka/actor/dsl/Inbox.java 2018-12-13 15:51:51.473673128 +0100
 @@ -2,5 +2,6 @@

--- a/plugin/src/test/resources/patches/2.12.3.patch
+++ b/plugin/src/test/resources/patches/2.12.3.patch
@@ -15,7 +15,7 @@
    }
    /**
     * class A.B
-@@ -98,8 +98,8 @@
+@@ -103,8 +103,8 @@
     * class A.C
     */
    static public  class C1 {
@@ -25,7 +25,7 @@
    }
    /**
     * object C1
-@@ -137,6 +137,11 @@
+@@ -142,6 +142,11 @@
    static public  java.lang.String stattic ()  { throw new RuntimeException(); }
    static public  java.lang.Object x ()  { throw new RuntimeException(); }
    /**
@@ -37,7 +37,7 @@
     * varargs
     * @param s (undocumented)
     * @return (undocumented)
-@@ -209,9 +214,4 @@
+@@ -214,9 +219,4 @@
     */
    public  int testthrows () throws java.lang.IllegalArgumentException, java.lang.NullPointerException { throw new RuntimeException(); }
    public  scala.runtime.Null$ getNull ()  { throw new RuntimeException(); }
@@ -47,6 +47,39 @@
 -   */
 -  public  akka.rk.buh.is.it.A.D$ D ()  { throw new RuntimeException(); }
  }
+--- target/expected_output/basic/akka/actor/Identify.java
++++ target/expected_output/basic/akka/actor/Identify.java
+@@ -2,6 +2,30 @@
+ public final class Identify implements scala.Product, scala.Serializable {
+   static public  akka.actor.Identify apply (Object messageId)  { throw new RuntimeException(); }
+   static public  scala.Option<java.lang.Object> unapply (akka.actor.Identify x$0)  { throw new RuntimeException(); }
++  static public  boolean apply$mcZD$sp (double v1)  { throw new RuntimeException(); }
++  static public  double apply$mcDD$sp (double v1)  { throw new RuntimeException(); }
++  static public  float apply$mcFD$sp (double v1)  { throw new RuntimeException(); }
++  static public  int apply$mcID$sp (double v1)  { throw new RuntimeException(); }
++  static public  long apply$mcJD$sp (double v1)  { throw new RuntimeException(); }
++  static public  void apply$mcVD$sp (double v1)  { throw new RuntimeException(); }
++  static public  boolean apply$mcZF$sp (float v1)  { throw new RuntimeException(); }
++  static public  double apply$mcDF$sp (float v1)  { throw new RuntimeException(); }
++  static public  float apply$mcFF$sp (float v1)  { throw new RuntimeException(); }
++  static public  int apply$mcIF$sp (float v1)  { throw new RuntimeException(); }
++  static public  long apply$mcJF$sp (float v1)  { throw new RuntimeException(); }
++  static public  void apply$mcVF$sp (float v1)  { throw new RuntimeException(); }
++  static public  boolean apply$mcZI$sp (int v1)  { throw new RuntimeException(); }
++  static public  double apply$mcDI$sp (int v1)  { throw new RuntimeException(); }
++  static public  float apply$mcFI$sp (int v1)  { throw new RuntimeException(); }
++  static public  int apply$mcII$sp (int v1)  { throw new RuntimeException(); }
++  static public  long apply$mcJI$sp (int v1)  { throw new RuntimeException(); }
++  static public  void apply$mcVI$sp (int v1)  { throw new RuntimeException(); }
++  static public  boolean apply$mcZJ$sp (long v1)  { throw new RuntimeException(); }
++  static public  double apply$mcDJ$sp (long v1)  { throw new RuntimeException(); }
++  static public  float apply$mcFJ$sp (long v1)  { throw new RuntimeException(); }
++  static public  int apply$mcIJ$sp (long v1)  { throw new RuntimeException(); }
++  static public  long apply$mcJJ$sp (long v1)  { throw new RuntimeException(); }
++  static public  void apply$mcVJ$sp (long v1)  { throw new RuntimeException(); }
+   public  Object messageId ()  { throw new RuntimeException(); }
+   // not preceding
+   public   Identify (Object messageId)  { throw new RuntimeException(); }
 --- target/expected_output/basic/akka/actor/dsl/Inbox.java    2018-12-13 15:51:52.473679518 +0100
 +++ target/expected_output/basic/akka/actor/dsl/Inbox.java 2018-12-13 15:51:51.473673128 +0100
 @@ -2,5 +2,6 @@

--- a/plugin/src/test/resources/patches/2.12.4.patch
+++ b/plugin/src/test/resources/patches/2.12.4.patch
@@ -47,39 +47,6 @@
 -   */
 -  public  akka.rk.buh.is.it.A.D$ D ()  { throw new RuntimeException(); }
  }
---- target/expected_output/basic/akka/actor/Identify.java
-+++ target/expected_output/basic/akka/actor/Identify.java
-@@ -2,6 +2,30 @@
- public final class Identify implements scala.Product, scala.Serializable {
-   static public  akka.actor.Identify apply (Object messageId)  { throw new RuntimeException(); }
-   static public  scala.Option<java.lang.Object> unapply (akka.actor.Identify x$0)  { throw new RuntimeException(); }
-+  static public  boolean apply$mcZD$sp (double v1)  { throw new RuntimeException(); }
-+  static public  double apply$mcDD$sp (double v1)  { throw new RuntimeException(); }
-+  static public  float apply$mcFD$sp (double v1)  { throw new RuntimeException(); }
-+  static public  int apply$mcID$sp (double v1)  { throw new RuntimeException(); }
-+  static public  long apply$mcJD$sp (double v1)  { throw new RuntimeException(); }
-+  static public  void apply$mcVD$sp (double v1)  { throw new RuntimeException(); }
-+  static public  boolean apply$mcZF$sp (float v1)  { throw new RuntimeException(); }
-+  static public  double apply$mcDF$sp (float v1)  { throw new RuntimeException(); }
-+  static public  float apply$mcFF$sp (float v1)  { throw new RuntimeException(); }
-+  static public  int apply$mcIF$sp (float v1)  { throw new RuntimeException(); }
-+  static public  long apply$mcJF$sp (float v1)  { throw new RuntimeException(); }
-+  static public  void apply$mcVF$sp (float v1)  { throw new RuntimeException(); }
-+  static public  boolean apply$mcZI$sp (int v1)  { throw new RuntimeException(); }
-+  static public  double apply$mcDI$sp (int v1)  { throw new RuntimeException(); }
-+  static public  float apply$mcFI$sp (int v1)  { throw new RuntimeException(); }
-+  static public  int apply$mcII$sp (int v1)  { throw new RuntimeException(); }
-+  static public  long apply$mcJI$sp (int v1)  { throw new RuntimeException(); }
-+  static public  void apply$mcVI$sp (int v1)  { throw new RuntimeException(); }
-+  static public  boolean apply$mcZJ$sp (long v1)  { throw new RuntimeException(); }
-+  static public  double apply$mcDJ$sp (long v1)  { throw new RuntimeException(); }
-+  static public  float apply$mcFJ$sp (long v1)  { throw new RuntimeException(); }
-+  static public  int apply$mcIJ$sp (long v1)  { throw new RuntimeException(); }
-+  static public  long apply$mcJJ$sp (long v1)  { throw new RuntimeException(); }
-+  static public  void apply$mcVJ$sp (long v1)  { throw new RuntimeException(); }
-   public  Object messageId ()  { throw new RuntimeException(); }
-   // not preceding
-   public   Identify (Object messageId)  { throw new RuntimeException(); }
 --- target/expected_output/basic/akka/actor/dsl/Inbox.java    2018-12-13 15:51:52.473679518 +0100
 +++ target/expected_output/basic/akka/actor/dsl/Inbox.java 2018-12-13 15:51:51.473673128 +0100
 @@ -2,5 +2,6 @@

--- a/plugin/src/test/resources/patches/2.12.4.patch
+++ b/plugin/src/test/resources/patches/2.12.4.patch
@@ -15,7 +15,7 @@
    }
    /**
     * class A.B
-@@ -98,8 +98,8 @@
+@@ -103,8 +103,8 @@
     * class A.C
     */
    static public  class C1 {
@@ -25,7 +25,7 @@
    }
    /**
     * object C1
-@@ -137,6 +137,11 @@
+@@ -142,6 +142,11 @@
    static public  java.lang.String stattic ()  { throw new RuntimeException(); }
    static public  java.lang.Object x ()  { throw new RuntimeException(); }
    /**
@@ -37,7 +37,7 @@
     * varargs
     * @param s (undocumented)
     * @return (undocumented)
-@@ -209,9 +214,4 @@
+@@ -214,9 +219,4 @@
     */
    public  int testthrows () throws java.lang.IllegalArgumentException, java.lang.NullPointerException { throw new RuntimeException(); }
    public  scala.runtime.Null$ getNull ()  { throw new RuntimeException(); }
@@ -47,6 +47,39 @@
 -   */
 -  public  akka.rk.buh.is.it.A.D$ D ()  { throw new RuntimeException(); }
  }
+--- target/expected_output/basic/akka/actor/Identify.java
++++ target/expected_output/basic/akka/actor/Identify.java
+@@ -2,6 +2,30 @@
+ public final class Identify implements scala.Product, scala.Serializable {
+   static public  akka.actor.Identify apply (Object messageId)  { throw new RuntimeException(); }
+   static public  scala.Option<java.lang.Object> unapply (akka.actor.Identify x$0)  { throw new RuntimeException(); }
++  static public  boolean apply$mcZD$sp (double v1)  { throw new RuntimeException(); }
++  static public  double apply$mcDD$sp (double v1)  { throw new RuntimeException(); }
++  static public  float apply$mcFD$sp (double v1)  { throw new RuntimeException(); }
++  static public  int apply$mcID$sp (double v1)  { throw new RuntimeException(); }
++  static public  long apply$mcJD$sp (double v1)  { throw new RuntimeException(); }
++  static public  void apply$mcVD$sp (double v1)  { throw new RuntimeException(); }
++  static public  boolean apply$mcZF$sp (float v1)  { throw new RuntimeException(); }
++  static public  double apply$mcDF$sp (float v1)  { throw new RuntimeException(); }
++  static public  float apply$mcFF$sp (float v1)  { throw new RuntimeException(); }
++  static public  int apply$mcIF$sp (float v1)  { throw new RuntimeException(); }
++  static public  long apply$mcJF$sp (float v1)  { throw new RuntimeException(); }
++  static public  void apply$mcVF$sp (float v1)  { throw new RuntimeException(); }
++  static public  boolean apply$mcZI$sp (int v1)  { throw new RuntimeException(); }
++  static public  double apply$mcDI$sp (int v1)  { throw new RuntimeException(); }
++  static public  float apply$mcFI$sp (int v1)  { throw new RuntimeException(); }
++  static public  int apply$mcII$sp (int v1)  { throw new RuntimeException(); }
++  static public  long apply$mcJI$sp (int v1)  { throw new RuntimeException(); }
++  static public  void apply$mcVI$sp (int v1)  { throw new RuntimeException(); }
++  static public  boolean apply$mcZJ$sp (long v1)  { throw new RuntimeException(); }
++  static public  double apply$mcDJ$sp (long v1)  { throw new RuntimeException(); }
++  static public  float apply$mcFJ$sp (long v1)  { throw new RuntimeException(); }
++  static public  int apply$mcIJ$sp (long v1)  { throw new RuntimeException(); }
++  static public  long apply$mcJJ$sp (long v1)  { throw new RuntimeException(); }
++  static public  void apply$mcVJ$sp (long v1)  { throw new RuntimeException(); }
+   public  Object messageId ()  { throw new RuntimeException(); }
+   // not preceding
+   public   Identify (Object messageId)  { throw new RuntimeException(); }
 --- target/expected_output/basic/akka/actor/dsl/Inbox.java    2018-12-13 15:51:52.473679518 +0100
 +++ target/expected_output/basic/akka/actor/dsl/Inbox.java 2018-12-13 15:51:51.473673128 +0100
 @@ -2,5 +2,6 @@

--- a/plugin/src/test/resources/patches/2.12.5.patch
+++ b/plugin/src/test/resources/patches/2.12.5.patch
@@ -47,39 +47,6 @@
 -   */
 -  public  akka.rk.buh.is.it.A.D$ D ()  { throw new RuntimeException(); }
  }
---- target/expected_output/basic/akka/actor/Identify.java
-+++ target/expected_output/basic/akka/actor/Identify.java
-@@ -2,6 +2,30 @@
- public final class Identify implements scala.Product, scala.Serializable {
-   static public  akka.actor.Identify apply (Object messageId)  { throw new RuntimeException(); }
-   static public  scala.Option<java.lang.Object> unapply (akka.actor.Identify x$0)  { throw new RuntimeException(); }
-+  static public  boolean apply$mcZD$sp (double v1)  { throw new RuntimeException(); }
-+  static public  double apply$mcDD$sp (double v1)  { throw new RuntimeException(); }
-+  static public  float apply$mcFD$sp (double v1)  { throw new RuntimeException(); }
-+  static public  int apply$mcID$sp (double v1)  { throw new RuntimeException(); }
-+  static public  long apply$mcJD$sp (double v1)  { throw new RuntimeException(); }
-+  static public  void apply$mcVD$sp (double v1)  { throw new RuntimeException(); }
-+  static public  boolean apply$mcZF$sp (float v1)  { throw new RuntimeException(); }
-+  static public  double apply$mcDF$sp (float v1)  { throw new RuntimeException(); }
-+  static public  float apply$mcFF$sp (float v1)  { throw new RuntimeException(); }
-+  static public  int apply$mcIF$sp (float v1)  { throw new RuntimeException(); }
-+  static public  long apply$mcJF$sp (float v1)  { throw new RuntimeException(); }
-+  static public  void apply$mcVF$sp (float v1)  { throw new RuntimeException(); }
-+  static public  boolean apply$mcZI$sp (int v1)  { throw new RuntimeException(); }
-+  static public  double apply$mcDI$sp (int v1)  { throw new RuntimeException(); }
-+  static public  float apply$mcFI$sp (int v1)  { throw new RuntimeException(); }
-+  static public  int apply$mcII$sp (int v1)  { throw new RuntimeException(); }
-+  static public  long apply$mcJI$sp (int v1)  { throw new RuntimeException(); }
-+  static public  void apply$mcVI$sp (int v1)  { throw new RuntimeException(); }
-+  static public  boolean apply$mcZJ$sp (long v1)  { throw new RuntimeException(); }
-+  static public  double apply$mcDJ$sp (long v1)  { throw new RuntimeException(); }
-+  static public  float apply$mcFJ$sp (long v1)  { throw new RuntimeException(); }
-+  static public  int apply$mcIJ$sp (long v1)  { throw new RuntimeException(); }
-+  static public  long apply$mcJJ$sp (long v1)  { throw new RuntimeException(); }
-+  static public  void apply$mcVJ$sp (long v1)  { throw new RuntimeException(); }
-   public  Object messageId ()  { throw new RuntimeException(); }
-   // not preceding
-   public   Identify (Object messageId)  { throw new RuntimeException(); }
 --- target/expected_output/basic/akka/actor/dsl/Inbox.java    2018-12-13 15:51:52.473679518 +0100
 +++ target/expected_output/basic/akka/actor/dsl/Inbox.java 2018-12-13 15:51:51.473673128 +0100
 @@ -2,5 +2,6 @@

--- a/plugin/src/test/resources/patches/2.12.5.patch
+++ b/plugin/src/test/resources/patches/2.12.5.patch
@@ -15,7 +15,7 @@
    }
    /**
     * class A.B
-@@ -98,8 +98,8 @@
+@@ -103,8 +103,8 @@
     * class A.C
     */
    static public  class C1 {
@@ -25,7 +25,7 @@
    }
    /**
     * object C1
-@@ -137,6 +137,11 @@
+@@ -142,6 +142,11 @@
    static public  java.lang.String stattic ()  { throw new RuntimeException(); }
    static public  java.lang.Object x ()  { throw new RuntimeException(); }
    /**
@@ -37,7 +37,7 @@
     * varargs
     * @param s (undocumented)
     * @return (undocumented)
-@@ -209,9 +214,4 @@
+@@ -214,9 +219,4 @@
     */
    public  int testthrows () throws java.lang.IllegalArgumentException, java.lang.NullPointerException { throw new RuntimeException(); }
    public  scala.runtime.Null$ getNull ()  { throw new RuntimeException(); }
@@ -47,6 +47,39 @@
 -   */
 -  public  akka.rk.buh.is.it.A.D$ D ()  { throw new RuntimeException(); }
  }
+--- target/expected_output/basic/akka/actor/Identify.java
++++ target/expected_output/basic/akka/actor/Identify.java
+@@ -2,6 +2,30 @@
+ public final class Identify implements scala.Product, scala.Serializable {
+   static public  akka.actor.Identify apply (Object messageId)  { throw new RuntimeException(); }
+   static public  scala.Option<java.lang.Object> unapply (akka.actor.Identify x$0)  { throw new RuntimeException(); }
++  static public  boolean apply$mcZD$sp (double v1)  { throw new RuntimeException(); }
++  static public  double apply$mcDD$sp (double v1)  { throw new RuntimeException(); }
++  static public  float apply$mcFD$sp (double v1)  { throw new RuntimeException(); }
++  static public  int apply$mcID$sp (double v1)  { throw new RuntimeException(); }
++  static public  long apply$mcJD$sp (double v1)  { throw new RuntimeException(); }
++  static public  void apply$mcVD$sp (double v1)  { throw new RuntimeException(); }
++  static public  boolean apply$mcZF$sp (float v1)  { throw new RuntimeException(); }
++  static public  double apply$mcDF$sp (float v1)  { throw new RuntimeException(); }
++  static public  float apply$mcFF$sp (float v1)  { throw new RuntimeException(); }
++  static public  int apply$mcIF$sp (float v1)  { throw new RuntimeException(); }
++  static public  long apply$mcJF$sp (float v1)  { throw new RuntimeException(); }
++  static public  void apply$mcVF$sp (float v1)  { throw new RuntimeException(); }
++  static public  boolean apply$mcZI$sp (int v1)  { throw new RuntimeException(); }
++  static public  double apply$mcDI$sp (int v1)  { throw new RuntimeException(); }
++  static public  float apply$mcFI$sp (int v1)  { throw new RuntimeException(); }
++  static public  int apply$mcII$sp (int v1)  { throw new RuntimeException(); }
++  static public  long apply$mcJI$sp (int v1)  { throw new RuntimeException(); }
++  static public  void apply$mcVI$sp (int v1)  { throw new RuntimeException(); }
++  static public  boolean apply$mcZJ$sp (long v1)  { throw new RuntimeException(); }
++  static public  double apply$mcDJ$sp (long v1)  { throw new RuntimeException(); }
++  static public  float apply$mcFJ$sp (long v1)  { throw new RuntimeException(); }
++  static public  int apply$mcIJ$sp (long v1)  { throw new RuntimeException(); }
++  static public  long apply$mcJJ$sp (long v1)  { throw new RuntimeException(); }
++  static public  void apply$mcVJ$sp (long v1)  { throw new RuntimeException(); }
+   public  Object messageId ()  { throw new RuntimeException(); }
+   // not preceding
+   public   Identify (Object messageId)  { throw new RuntimeException(); }
 --- target/expected_output/basic/akka/actor/dsl/Inbox.java    2018-12-13 15:51:52.473679518 +0100
 +++ target/expected_output/basic/akka/actor/dsl/Inbox.java 2018-12-13 15:51:51.473673128 +0100
 @@ -2,5 +2,6 @@

--- a/plugin/src/test/resources/patches/2.12.6.patch
+++ b/plugin/src/test/resources/patches/2.12.6.patch
@@ -47,39 +47,6 @@
 -   */
 -  public  akka.rk.buh.is.it.A.D$ D ()  { throw new RuntimeException(); }
  }
---- target/expected_output/basic/akka/actor/Identify.java
-+++ target/expected_output/basic/akka/actor/Identify.java
-@@ -2,6 +2,30 @@
- public final class Identify implements scala.Product, scala.Serializable {
-   static public  akka.actor.Identify apply (Object messageId)  { throw new RuntimeException(); }
-   static public  scala.Option<java.lang.Object> unapply (akka.actor.Identify x$0)  { throw new RuntimeException(); }
-+  static public  boolean apply$mcZD$sp (double v1)  { throw new RuntimeException(); }
-+  static public  double apply$mcDD$sp (double v1)  { throw new RuntimeException(); }
-+  static public  float apply$mcFD$sp (double v1)  { throw new RuntimeException(); }
-+  static public  int apply$mcID$sp (double v1)  { throw new RuntimeException(); }
-+  static public  long apply$mcJD$sp (double v1)  { throw new RuntimeException(); }
-+  static public  void apply$mcVD$sp (double v1)  { throw new RuntimeException(); }
-+  static public  boolean apply$mcZF$sp (float v1)  { throw new RuntimeException(); }
-+  static public  double apply$mcDF$sp (float v1)  { throw new RuntimeException(); }
-+  static public  float apply$mcFF$sp (float v1)  { throw new RuntimeException(); }
-+  static public  int apply$mcIF$sp (float v1)  { throw new RuntimeException(); }
-+  static public  long apply$mcJF$sp (float v1)  { throw new RuntimeException(); }
-+  static public  void apply$mcVF$sp (float v1)  { throw new RuntimeException(); }
-+  static public  boolean apply$mcZI$sp (int v1)  { throw new RuntimeException(); }
-+  static public  double apply$mcDI$sp (int v1)  { throw new RuntimeException(); }
-+  static public  float apply$mcFI$sp (int v1)  { throw new RuntimeException(); }
-+  static public  int apply$mcII$sp (int v1)  { throw new RuntimeException(); }
-+  static public  long apply$mcJI$sp (int v1)  { throw new RuntimeException(); }
-+  static public  void apply$mcVI$sp (int v1)  { throw new RuntimeException(); }
-+  static public  boolean apply$mcZJ$sp (long v1)  { throw new RuntimeException(); }
-+  static public  double apply$mcDJ$sp (long v1)  { throw new RuntimeException(); }
-+  static public  float apply$mcFJ$sp (long v1)  { throw new RuntimeException(); }
-+  static public  int apply$mcIJ$sp (long v1)  { throw new RuntimeException(); }
-+  static public  long apply$mcJJ$sp (long v1)  { throw new RuntimeException(); }
-+  static public  void apply$mcVJ$sp (long v1)  { throw new RuntimeException(); }
-   public  Object messageId ()  { throw new RuntimeException(); }
-   // not preceding
-   public   Identify (Object messageId)  { throw new RuntimeException(); }
 --- target/expected_output/basic/akka/actor/dsl/Inbox.java    2018-12-13 15:51:52.473679518 +0100
 +++ target/expected_output/basic/akka/actor/dsl/Inbox.java 2018-12-13 15:51:51.473673128 +0100
 @@ -2,5 +2,6 @@

--- a/plugin/src/test/resources/patches/2.12.6.patch
+++ b/plugin/src/test/resources/patches/2.12.6.patch
@@ -15,7 +15,7 @@
    }
    /**
     * class A.B
-@@ -98,8 +98,8 @@
+@@ -103,8 +103,8 @@
     * class A.C
     */
    static public  class C1 {
@@ -25,7 +25,7 @@
    }
    /**
     * object C1
-@@ -137,6 +137,11 @@
+@@ -142,6 +142,11 @@
    static public  java.lang.String stattic ()  { throw new RuntimeException(); }
    static public  java.lang.Object x ()  { throw new RuntimeException(); }
    /**
@@ -37,7 +37,7 @@
     * varargs
     * @param s (undocumented)
     * @return (undocumented)
-@@ -209,9 +214,4 @@
+@@ -214,9 +219,4 @@
     */
    public  int testthrows () throws java.lang.IllegalArgumentException, java.lang.NullPointerException { throw new RuntimeException(); }
    public  scala.runtime.Null$ getNull ()  { throw new RuntimeException(); }
@@ -47,6 +47,39 @@
 -   */
 -  public  akka.rk.buh.is.it.A.D$ D ()  { throw new RuntimeException(); }
  }
+--- target/expected_output/basic/akka/actor/Identify.java
++++ target/expected_output/basic/akka/actor/Identify.java
+@@ -2,6 +2,30 @@
+ public final class Identify implements scala.Product, scala.Serializable {
+   static public  akka.actor.Identify apply (Object messageId)  { throw new RuntimeException(); }
+   static public  scala.Option<java.lang.Object> unapply (akka.actor.Identify x$0)  { throw new RuntimeException(); }
++  static public  boolean apply$mcZD$sp (double v1)  { throw new RuntimeException(); }
++  static public  double apply$mcDD$sp (double v1)  { throw new RuntimeException(); }
++  static public  float apply$mcFD$sp (double v1)  { throw new RuntimeException(); }
++  static public  int apply$mcID$sp (double v1)  { throw new RuntimeException(); }
++  static public  long apply$mcJD$sp (double v1)  { throw new RuntimeException(); }
++  static public  void apply$mcVD$sp (double v1)  { throw new RuntimeException(); }
++  static public  boolean apply$mcZF$sp (float v1)  { throw new RuntimeException(); }
++  static public  double apply$mcDF$sp (float v1)  { throw new RuntimeException(); }
++  static public  float apply$mcFF$sp (float v1)  { throw new RuntimeException(); }
++  static public  int apply$mcIF$sp (float v1)  { throw new RuntimeException(); }
++  static public  long apply$mcJF$sp (float v1)  { throw new RuntimeException(); }
++  static public  void apply$mcVF$sp (float v1)  { throw new RuntimeException(); }
++  static public  boolean apply$mcZI$sp (int v1)  { throw new RuntimeException(); }
++  static public  double apply$mcDI$sp (int v1)  { throw new RuntimeException(); }
++  static public  float apply$mcFI$sp (int v1)  { throw new RuntimeException(); }
++  static public  int apply$mcII$sp (int v1)  { throw new RuntimeException(); }
++  static public  long apply$mcJI$sp (int v1)  { throw new RuntimeException(); }
++  static public  void apply$mcVI$sp (int v1)  { throw new RuntimeException(); }
++  static public  boolean apply$mcZJ$sp (long v1)  { throw new RuntimeException(); }
++  static public  double apply$mcDJ$sp (long v1)  { throw new RuntimeException(); }
++  static public  float apply$mcFJ$sp (long v1)  { throw new RuntimeException(); }
++  static public  int apply$mcIJ$sp (long v1)  { throw new RuntimeException(); }
++  static public  long apply$mcJJ$sp (long v1)  { throw new RuntimeException(); }
++  static public  void apply$mcVJ$sp (long v1)  { throw new RuntimeException(); }
+   public  Object messageId ()  { throw new RuntimeException(); }
+   // not preceding
+   public   Identify (Object messageId)  { throw new RuntimeException(); }
 --- target/expected_output/basic/akka/actor/dsl/Inbox.java    2018-12-13 15:51:52.473679518 +0100
 +++ target/expected_output/basic/akka/actor/dsl/Inbox.java 2018-12-13 15:51:51.473673128 +0100
 @@ -2,5 +2,6 @@

--- a/plugin/src/test/resources/patches/2.12.7.patch
+++ b/plugin/src/test/resources/patches/2.12.7.patch
@@ -47,39 +47,6 @@
 -   */
 -  public  akka.rk.buh.is.it.A.D$ D ()  { throw new RuntimeException(); }
  }
---- target/expected_output/basic/akka/actor/Identify.java
-+++ target/expected_output/basic/akka/actor/Identify.java
-@@ -2,6 +2,30 @@
- public final class Identify implements scala.Product, scala.Serializable {
-   static public  akka.actor.Identify apply (Object messageId)  { throw new RuntimeException(); }
-   static public  scala.Option<java.lang.Object> unapply (akka.actor.Identify x$0)  { throw new RuntimeException(); }
-+  static public  boolean apply$mcZD$sp (double v1)  { throw new RuntimeException(); }
-+  static public  double apply$mcDD$sp (double v1)  { throw new RuntimeException(); }
-+  static public  float apply$mcFD$sp (double v1)  { throw new RuntimeException(); }
-+  static public  int apply$mcID$sp (double v1)  { throw new RuntimeException(); }
-+  static public  long apply$mcJD$sp (double v1)  { throw new RuntimeException(); }
-+  static public  void apply$mcVD$sp (double v1)  { throw new RuntimeException(); }
-+  static public  boolean apply$mcZF$sp (float v1)  { throw new RuntimeException(); }
-+  static public  double apply$mcDF$sp (float v1)  { throw new RuntimeException(); }
-+  static public  float apply$mcFF$sp (float v1)  { throw new RuntimeException(); }
-+  static public  int apply$mcIF$sp (float v1)  { throw new RuntimeException(); }
-+  static public  long apply$mcJF$sp (float v1)  { throw new RuntimeException(); }
-+  static public  void apply$mcVF$sp (float v1)  { throw new RuntimeException(); }
-+  static public  boolean apply$mcZI$sp (int v1)  { throw new RuntimeException(); }
-+  static public  double apply$mcDI$sp (int v1)  { throw new RuntimeException(); }
-+  static public  float apply$mcFI$sp (int v1)  { throw new RuntimeException(); }
-+  static public  int apply$mcII$sp (int v1)  { throw new RuntimeException(); }
-+  static public  long apply$mcJI$sp (int v1)  { throw new RuntimeException(); }
-+  static public  void apply$mcVI$sp (int v1)  { throw new RuntimeException(); }
-+  static public  boolean apply$mcZJ$sp (long v1)  { throw new RuntimeException(); }
-+  static public  double apply$mcDJ$sp (long v1)  { throw new RuntimeException(); }
-+  static public  float apply$mcFJ$sp (long v1)  { throw new RuntimeException(); }
-+  static public  int apply$mcIJ$sp (long v1)  { throw new RuntimeException(); }
-+  static public  long apply$mcJJ$sp (long v1)  { throw new RuntimeException(); }
-+  static public  void apply$mcVJ$sp (long v1)  { throw new RuntimeException(); }
-   public  Object messageId ()  { throw new RuntimeException(); }
-   // not preceding
-   public   Identify (Object messageId)  { throw new RuntimeException(); }
 --- target/expected_output/basic/akka/actor/dsl/Inbox.java    2018-12-13 15:51:52.473679518 +0100
 +++ target/expected_output/basic/akka/actor/dsl/Inbox.java 2018-12-13 15:51:51.473673128 +0100
 @@ -2,5 +2,6 @@

--- a/plugin/src/test/resources/patches/2.12.7.patch
+++ b/plugin/src/test/resources/patches/2.12.7.patch
@@ -15,7 +15,7 @@
    }
    /**
     * class A.B
-@@ -98,8 +98,8 @@
+@@ -103,8 +103,8 @@
     * class A.C
     */
    static public  class C1 {
@@ -25,7 +25,7 @@
    }
    /**
     * object C1
-@@ -137,6 +137,11 @@
+@@ -142,6 +142,11 @@
    static public  java.lang.String stattic ()  { throw new RuntimeException(); }
    static public  java.lang.Object x ()  { throw new RuntimeException(); }
    /**
@@ -37,7 +37,7 @@
     * varargs
     * @param s (undocumented)
     * @return (undocumented)
-@@ -209,9 +214,4 @@
+@@ -214,9 +219,4 @@
     */
    public  int testthrows () throws java.lang.IllegalArgumentException, java.lang.NullPointerException { throw new RuntimeException(); }
    public  scala.runtime.Null$ getNull ()  { throw new RuntimeException(); }
@@ -47,6 +47,39 @@
 -   */
 -  public  akka.rk.buh.is.it.A.D$ D ()  { throw new RuntimeException(); }
  }
+--- target/expected_output/basic/akka/actor/Identify.java
++++ target/expected_output/basic/akka/actor/Identify.java
+@@ -2,6 +2,30 @@
+ public final class Identify implements scala.Product, scala.Serializable {
+   static public  akka.actor.Identify apply (Object messageId)  { throw new RuntimeException(); }
+   static public  scala.Option<java.lang.Object> unapply (akka.actor.Identify x$0)  { throw new RuntimeException(); }
++  static public  boolean apply$mcZD$sp (double v1)  { throw new RuntimeException(); }
++  static public  double apply$mcDD$sp (double v1)  { throw new RuntimeException(); }
++  static public  float apply$mcFD$sp (double v1)  { throw new RuntimeException(); }
++  static public  int apply$mcID$sp (double v1)  { throw new RuntimeException(); }
++  static public  long apply$mcJD$sp (double v1)  { throw new RuntimeException(); }
++  static public  void apply$mcVD$sp (double v1)  { throw new RuntimeException(); }
++  static public  boolean apply$mcZF$sp (float v1)  { throw new RuntimeException(); }
++  static public  double apply$mcDF$sp (float v1)  { throw new RuntimeException(); }
++  static public  float apply$mcFF$sp (float v1)  { throw new RuntimeException(); }
++  static public  int apply$mcIF$sp (float v1)  { throw new RuntimeException(); }
++  static public  long apply$mcJF$sp (float v1)  { throw new RuntimeException(); }
++  static public  void apply$mcVF$sp (float v1)  { throw new RuntimeException(); }
++  static public  boolean apply$mcZI$sp (int v1)  { throw new RuntimeException(); }
++  static public  double apply$mcDI$sp (int v1)  { throw new RuntimeException(); }
++  static public  float apply$mcFI$sp (int v1)  { throw new RuntimeException(); }
++  static public  int apply$mcII$sp (int v1)  { throw new RuntimeException(); }
++  static public  long apply$mcJI$sp (int v1)  { throw new RuntimeException(); }
++  static public  void apply$mcVI$sp (int v1)  { throw new RuntimeException(); }
++  static public  boolean apply$mcZJ$sp (long v1)  { throw new RuntimeException(); }
++  static public  double apply$mcDJ$sp (long v1)  { throw new RuntimeException(); }
++  static public  float apply$mcFJ$sp (long v1)  { throw new RuntimeException(); }
++  static public  int apply$mcIJ$sp (long v1)  { throw new RuntimeException(); }
++  static public  long apply$mcJJ$sp (long v1)  { throw new RuntimeException(); }
++  static public  void apply$mcVJ$sp (long v1)  { throw new RuntimeException(); }
+   public  Object messageId ()  { throw new RuntimeException(); }
+   // not preceding
+   public   Identify (Object messageId)  { throw new RuntimeException(); }
 --- target/expected_output/basic/akka/actor/dsl/Inbox.java    2018-12-13 15:51:52.473679518 +0100
 +++ target/expected_output/basic/akka/actor/dsl/Inbox.java 2018-12-13 15:51:51.473673128 +0100
 @@ -2,5 +2,6 @@

--- a/plugin/src/test/resources/patches/2.12.8.patch
+++ b/plugin/src/test/resources/patches/2.12.8.patch
@@ -47,39 +47,6 @@
 -   */
 -  public  akka.rk.buh.is.it.A.D$ D ()  { throw new RuntimeException(); }
  }
---- target/expected_output/basic/akka/actor/Identify.java
-+++ target/expected_output/basic/akka/actor/Identify.java
-@@ -2,6 +2,30 @@
- public final class Identify implements scala.Product, scala.Serializable {
-   static public  akka.actor.Identify apply (Object messageId)  { throw new RuntimeException(); }
-   static public  scala.Option<java.lang.Object> unapply (akka.actor.Identify x$0)  { throw new RuntimeException(); }
-+  static public  boolean apply$mcZD$sp (double v1)  { throw new RuntimeException(); }
-+  static public  double apply$mcDD$sp (double v1)  { throw new RuntimeException(); }
-+  static public  float apply$mcFD$sp (double v1)  { throw new RuntimeException(); }
-+  static public  int apply$mcID$sp (double v1)  { throw new RuntimeException(); }
-+  static public  long apply$mcJD$sp (double v1)  { throw new RuntimeException(); }
-+  static public  void apply$mcVD$sp (double v1)  { throw new RuntimeException(); }
-+  static public  boolean apply$mcZF$sp (float v1)  { throw new RuntimeException(); }
-+  static public  double apply$mcDF$sp (float v1)  { throw new RuntimeException(); }
-+  static public  float apply$mcFF$sp (float v1)  { throw new RuntimeException(); }
-+  static public  int apply$mcIF$sp (float v1)  { throw new RuntimeException(); }
-+  static public  long apply$mcJF$sp (float v1)  { throw new RuntimeException(); }
-+  static public  void apply$mcVF$sp (float v1)  { throw new RuntimeException(); }
-+  static public  boolean apply$mcZI$sp (int v1)  { throw new RuntimeException(); }
-+  static public  double apply$mcDI$sp (int v1)  { throw new RuntimeException(); }
-+  static public  float apply$mcFI$sp (int v1)  { throw new RuntimeException(); }
-+  static public  int apply$mcII$sp (int v1)  { throw new RuntimeException(); }
-+  static public  long apply$mcJI$sp (int v1)  { throw new RuntimeException(); }
-+  static public  void apply$mcVI$sp (int v1)  { throw new RuntimeException(); }
-+  static public  boolean apply$mcZJ$sp (long v1)  { throw new RuntimeException(); }
-+  static public  double apply$mcDJ$sp (long v1)  { throw new RuntimeException(); }
-+  static public  float apply$mcFJ$sp (long v1)  { throw new RuntimeException(); }
-+  static public  int apply$mcIJ$sp (long v1)  { throw new RuntimeException(); }
-+  static public  long apply$mcJJ$sp (long v1)  { throw new RuntimeException(); }
-+  static public  void apply$mcVJ$sp (long v1)  { throw new RuntimeException(); }
-   public  Object messageId ()  { throw new RuntimeException(); }
-   // not preceding
-   public   Identify (Object messageId)  { throw new RuntimeException(); }
 --- target/expected_output/basic/akka/actor/dsl/Inbox.java    2018-12-13 15:51:52.473679518 +0100
 +++ target/expected_output/basic/akka/actor/dsl/Inbox.java 2018-12-13 15:51:51.473673128 +0100
 @@ -2,5 +2,6 @@

--- a/plugin/src/test/resources/patches/2.12.8.patch
+++ b/plugin/src/test/resources/patches/2.12.8.patch
@@ -15,7 +15,7 @@
    }
    /**
     * class A.B
-@@ -98,8 +98,8 @@
+@@ -103,8 +103,8 @@
     * class A.C
     */
    static public  class C1 {
@@ -25,7 +25,7 @@
    }
    /**
     * object C1
-@@ -137,6 +137,11 @@
+@@ -142,6 +142,11 @@
    static public  java.lang.String stattic ()  { throw new RuntimeException(); }
    static public  java.lang.Object x ()  { throw new RuntimeException(); }
    /**
@@ -37,7 +37,7 @@
     * varargs
     * @param s (undocumented)
     * @return (undocumented)
-@@ -209,9 +214,4 @@
+@@ -214,9 +219,4 @@
     */
    public  int testthrows () throws java.lang.IllegalArgumentException, java.lang.NullPointerException { throw new RuntimeException(); }
    public  scala.runtime.Null$ getNull ()  { throw new RuntimeException(); }
@@ -47,6 +47,39 @@
 -   */
 -  public  akka.rk.buh.is.it.A.D$ D ()  { throw new RuntimeException(); }
  }
+--- target/expected_output/basic/akka/actor/Identify.java
++++ target/expected_output/basic/akka/actor/Identify.java
+@@ -2,6 +2,30 @@
+ public final class Identify implements scala.Product, scala.Serializable {
+   static public  akka.actor.Identify apply (Object messageId)  { throw new RuntimeException(); }
+   static public  scala.Option<java.lang.Object> unapply (akka.actor.Identify x$0)  { throw new RuntimeException(); }
++  static public  boolean apply$mcZD$sp (double v1)  { throw new RuntimeException(); }
++  static public  double apply$mcDD$sp (double v1)  { throw new RuntimeException(); }
++  static public  float apply$mcFD$sp (double v1)  { throw new RuntimeException(); }
++  static public  int apply$mcID$sp (double v1)  { throw new RuntimeException(); }
++  static public  long apply$mcJD$sp (double v1)  { throw new RuntimeException(); }
++  static public  void apply$mcVD$sp (double v1)  { throw new RuntimeException(); }
++  static public  boolean apply$mcZF$sp (float v1)  { throw new RuntimeException(); }
++  static public  double apply$mcDF$sp (float v1)  { throw new RuntimeException(); }
++  static public  float apply$mcFF$sp (float v1)  { throw new RuntimeException(); }
++  static public  int apply$mcIF$sp (float v1)  { throw new RuntimeException(); }
++  static public  long apply$mcJF$sp (float v1)  { throw new RuntimeException(); }
++  static public  void apply$mcVF$sp (float v1)  { throw new RuntimeException(); }
++  static public  boolean apply$mcZI$sp (int v1)  { throw new RuntimeException(); }
++  static public  double apply$mcDI$sp (int v1)  { throw new RuntimeException(); }
++  static public  float apply$mcFI$sp (int v1)  { throw new RuntimeException(); }
++  static public  int apply$mcII$sp (int v1)  { throw new RuntimeException(); }
++  static public  long apply$mcJI$sp (int v1)  { throw new RuntimeException(); }
++  static public  void apply$mcVI$sp (int v1)  { throw new RuntimeException(); }
++  static public  boolean apply$mcZJ$sp (long v1)  { throw new RuntimeException(); }
++  static public  double apply$mcDJ$sp (long v1)  { throw new RuntimeException(); }
++  static public  float apply$mcFJ$sp (long v1)  { throw new RuntimeException(); }
++  static public  int apply$mcIJ$sp (long v1)  { throw new RuntimeException(); }
++  static public  long apply$mcJJ$sp (long v1)  { throw new RuntimeException(); }
++  static public  void apply$mcVJ$sp (long v1)  { throw new RuntimeException(); }
+   public  Object messageId ()  { throw new RuntimeException(); }
+   // not preceding
+   public   Identify (Object messageId)  { throw new RuntimeException(); }
 --- target/expected_output/basic/akka/actor/dsl/Inbox.java    2018-12-13 15:51:52.473679518 +0100
 +++ target/expected_output/basic/akka/actor/dsl/Inbox.java 2018-12-13 15:51:51.473673128 +0100
 @@ -2,5 +2,6 @@

--- a/plugin/src/test/resources/patches/2.12.9.patch
+++ b/plugin/src/test/resources/patches/2.12.9.patch
@@ -47,39 +47,6 @@
 -   */
 -  public  akka.rk.buh.is.it.A.D$ D ()  { throw new RuntimeException(); }
  }
---- target/expected_output/basic/akka/actor/Identify.java
-+++ target/expected_output/basic/akka/actor/Identify.java
-@@ -2,6 +2,30 @@
- public final class Identify implements scala.Product, scala.Serializable {
-   static public  akka.actor.Identify apply (Object messageId)  { throw new RuntimeException(); }
-   static public  scala.Option<java.lang.Object> unapply (akka.actor.Identify x$0)  { throw new RuntimeException(); }
-+  static public  boolean apply$mcZD$sp (double v1)  { throw new RuntimeException(); }
-+  static public  double apply$mcDD$sp (double v1)  { throw new RuntimeException(); }
-+  static public  float apply$mcFD$sp (double v1)  { throw new RuntimeException(); }
-+  static public  int apply$mcID$sp (double v1)  { throw new RuntimeException(); }
-+  static public  long apply$mcJD$sp (double v1)  { throw new RuntimeException(); }
-+  static public  void apply$mcVD$sp (double v1)  { throw new RuntimeException(); }
-+  static public  boolean apply$mcZF$sp (float v1)  { throw new RuntimeException(); }
-+  static public  double apply$mcDF$sp (float v1)  { throw new RuntimeException(); }
-+  static public  float apply$mcFF$sp (float v1)  { throw new RuntimeException(); }
-+  static public  int apply$mcIF$sp (float v1)  { throw new RuntimeException(); }
-+  static public  long apply$mcJF$sp (float v1)  { throw new RuntimeException(); }
-+  static public  void apply$mcVF$sp (float v1)  { throw new RuntimeException(); }
-+  static public  boolean apply$mcZI$sp (int v1)  { throw new RuntimeException(); }
-+  static public  double apply$mcDI$sp (int v1)  { throw new RuntimeException(); }
-+  static public  float apply$mcFI$sp (int v1)  { throw new RuntimeException(); }
-+  static public  int apply$mcII$sp (int v1)  { throw new RuntimeException(); }
-+  static public  long apply$mcJI$sp (int v1)  { throw new RuntimeException(); }
-+  static public  void apply$mcVI$sp (int v1)  { throw new RuntimeException(); }
-+  static public  boolean apply$mcZJ$sp (long v1)  { throw new RuntimeException(); }
-+  static public  double apply$mcDJ$sp (long v1)  { throw new RuntimeException(); }
-+  static public  float apply$mcFJ$sp (long v1)  { throw new RuntimeException(); }
-+  static public  int apply$mcIJ$sp (long v1)  { throw new RuntimeException(); }
-+  static public  long apply$mcJJ$sp (long v1)  { throw new RuntimeException(); }
-+  static public  void apply$mcVJ$sp (long v1)  { throw new RuntimeException(); }
-   public  Object messageId ()  { throw new RuntimeException(); }
-   // not preceding
-   public   Identify (Object messageId)  { throw new RuntimeException(); }
 --- target/expected_output/basic/akka/actor/dsl/Inbox.java    2018-12-13 15:51:52.473679518 +0100
 +++ target/expected_output/basic/akka/actor/dsl/Inbox.java 2018-12-13 15:51:51.473673128 +0100
 @@ -2,5 +2,6 @@

--- a/plugin/src/test/resources/patches/2.12.9.patch
+++ b/plugin/src/test/resources/patches/2.12.9.patch
@@ -15,7 +15,7 @@
    }
    /**
     * class A.B
-@@ -98,8 +98,8 @@
+@@ -103,8 +103,8 @@
     * class A.C
     */
    static public  class C1 {
@@ -25,7 +25,7 @@
    }
    /**
     * object C1
-@@ -137,6 +137,11 @@
+@@ -142,6 +142,11 @@
    static public  java.lang.String stattic ()  { throw new RuntimeException(); }
    static public  java.lang.Object x ()  { throw new RuntimeException(); }
    /**
@@ -37,7 +37,7 @@
     * varargs
     * @param s (undocumented)
     * @return (undocumented)
-@@ -209,9 +214,4 @@
+@@ -214,9 +219,4 @@
     */
    public  int testthrows () throws java.lang.IllegalArgumentException, java.lang.NullPointerException { throw new RuntimeException(); }
    public  scala.runtime.Null$ getNull ()  { throw new RuntimeException(); }
@@ -47,6 +47,39 @@
 -   */
 -  public  akka.rk.buh.is.it.A.D$ D ()  { throw new RuntimeException(); }
  }
+--- target/expected_output/basic/akka/actor/Identify.java
++++ target/expected_output/basic/akka/actor/Identify.java
+@@ -2,6 +2,30 @@
+ public final class Identify implements scala.Product, scala.Serializable {
+   static public  akka.actor.Identify apply (Object messageId)  { throw new RuntimeException(); }
+   static public  scala.Option<java.lang.Object> unapply (akka.actor.Identify x$0)  { throw new RuntimeException(); }
++  static public  boolean apply$mcZD$sp (double v1)  { throw new RuntimeException(); }
++  static public  double apply$mcDD$sp (double v1)  { throw new RuntimeException(); }
++  static public  float apply$mcFD$sp (double v1)  { throw new RuntimeException(); }
++  static public  int apply$mcID$sp (double v1)  { throw new RuntimeException(); }
++  static public  long apply$mcJD$sp (double v1)  { throw new RuntimeException(); }
++  static public  void apply$mcVD$sp (double v1)  { throw new RuntimeException(); }
++  static public  boolean apply$mcZF$sp (float v1)  { throw new RuntimeException(); }
++  static public  double apply$mcDF$sp (float v1)  { throw new RuntimeException(); }
++  static public  float apply$mcFF$sp (float v1)  { throw new RuntimeException(); }
++  static public  int apply$mcIF$sp (float v1)  { throw new RuntimeException(); }
++  static public  long apply$mcJF$sp (float v1)  { throw new RuntimeException(); }
++  static public  void apply$mcVF$sp (float v1)  { throw new RuntimeException(); }
++  static public  boolean apply$mcZI$sp (int v1)  { throw new RuntimeException(); }
++  static public  double apply$mcDI$sp (int v1)  { throw new RuntimeException(); }
++  static public  float apply$mcFI$sp (int v1)  { throw new RuntimeException(); }
++  static public  int apply$mcII$sp (int v1)  { throw new RuntimeException(); }
++  static public  long apply$mcJI$sp (int v1)  { throw new RuntimeException(); }
++  static public  void apply$mcVI$sp (int v1)  { throw new RuntimeException(); }
++  static public  boolean apply$mcZJ$sp (long v1)  { throw new RuntimeException(); }
++  static public  double apply$mcDJ$sp (long v1)  { throw new RuntimeException(); }
++  static public  float apply$mcFJ$sp (long v1)  { throw new RuntimeException(); }
++  static public  int apply$mcIJ$sp (long v1)  { throw new RuntimeException(); }
++  static public  long apply$mcJJ$sp (long v1)  { throw new RuntimeException(); }
++  static public  void apply$mcVJ$sp (long v1)  { throw new RuntimeException(); }
+   public  Object messageId ()  { throw new RuntimeException(); }
+   // not preceding
+   public   Identify (Object messageId)  { throw new RuntimeException(); }
 --- target/expected_output/basic/akka/actor/dsl/Inbox.java    2018-12-13 15:51:52.473679518 +0100
 +++ target/expected_output/basic/akka/actor/dsl/Inbox.java 2018-12-13 15:51:51.473673128 +0100
 @@ -2,5 +2,6 @@

--- a/plugin/src/test/resources/patches/2.13.0.patch
+++ b/plugin/src/test/resources/patches/2.13.0.patch
@@ -9,40 +9,14 @@
     */
 --- target/expected_output/basic/akka/actor/Identify.java
 +++ target/expected_output/basic/akka/actor/Identify.java
-@@ -1,7 +1,31 @@
+@@ -1,5 +1,5 @@
  package akka.actor;
 -public final class Identify implements scala.Product, scala.Serializable {
 +public final class Identify implements scala.Product, java.io.Serializable {
    static public  akka.actor.Identify apply (Object messageId)  { throw new RuntimeException(); }
    static public  scala.Option<java.lang.Object> unapply (akka.actor.Identify x$0)  { throw new RuntimeException(); }
-+  static public  boolean apply$mcZD$sp (double v1)  { throw new RuntimeException(); }
-+  static public  double apply$mcDD$sp (double v1)  { throw new RuntimeException(); }
-+  static public  float apply$mcFD$sp (double v1)  { throw new RuntimeException(); }
-+  static public  int apply$mcID$sp (double v1)  { throw new RuntimeException(); }
-+  static public  long apply$mcJD$sp (double v1)  { throw new RuntimeException(); }
-+  static public  void apply$mcVD$sp (double v1)  { throw new RuntimeException(); }
-+  static public  boolean apply$mcZF$sp (float v1)  { throw new RuntimeException(); }
-+  static public  double apply$mcDF$sp (float v1)  { throw new RuntimeException(); }
-+  static public  float apply$mcFF$sp (float v1)  { throw new RuntimeException(); }
-+  static public  int apply$mcIF$sp (float v1)  { throw new RuntimeException(); }
-+  static public  long apply$mcJF$sp (float v1)  { throw new RuntimeException(); }
-+  static public  void apply$mcVF$sp (float v1)  { throw new RuntimeException(); }
-+  static public  boolean apply$mcZI$sp (int v1)  { throw new RuntimeException(); }
-+  static public  double apply$mcDI$sp (int v1)  { throw new RuntimeException(); }
-+  static public  float apply$mcFI$sp (int v1)  { throw new RuntimeException(); }
-+  static public  int apply$mcII$sp (int v1)  { throw new RuntimeException(); }
-+  static public  long apply$mcJI$sp (int v1)  { throw new RuntimeException(); }
-+  static public  void apply$mcVI$sp (int v1)  { throw new RuntimeException(); }
-+  static public  boolean apply$mcZJ$sp (long v1)  { throw new RuntimeException(); }
-+  static public  double apply$mcDJ$sp (long v1)  { throw new RuntimeException(); }
-+  static public  float apply$mcFJ$sp (long v1)  { throw new RuntimeException(); }
-+  static public  int apply$mcIJ$sp (long v1)  { throw new RuntimeException(); }
-+  static public  long apply$mcJJ$sp (long v1)  { throw new RuntimeException(); }
-+  static public  void apply$mcVJ$sp (long v1)  { throw new RuntimeException(); }
    public  Object messageId ()  { throw new RuntimeException(); }
-   // not preceding
-   public   Identify (Object messageId)  { throw new RuntimeException(); }
-@@ -13,6 +37,7 @@
+@@ -13,6 +13,7 @@
    public  Object productElement (int x$1)  { throw new RuntimeException(); }
    public  scala.collection.Iterator<java.lang.Object> productIterator ()  { throw new RuntimeException(); }
    public  boolean canEqual (Object x$1)  { throw new RuntimeException(); }

--- a/plugin/src/test/resources/patches/2.13.0.patch
+++ b/plugin/src/test/resources/patches/2.13.0.patch
@@ -9,14 +9,40 @@
     */
 --- target/expected_output/basic/akka/actor/Identify.java
 +++ target/expected_output/basic/akka/actor/Identify.java
-@@ -1,5 +1,5 @@
+@@ -1,7 +1,31 @@
  package akka.actor;
 -public final class Identify implements scala.Product, scala.Serializable {
 +public final class Identify implements scala.Product, java.io.Serializable {
    static public  akka.actor.Identify apply (Object messageId)  { throw new RuntimeException(); }
    static public  scala.Option<java.lang.Object> unapply (akka.actor.Identify x$0)  { throw new RuntimeException(); }
++  static public  boolean apply$mcZD$sp (double v1)  { throw new RuntimeException(); }
++  static public  double apply$mcDD$sp (double v1)  { throw new RuntimeException(); }
++  static public  float apply$mcFD$sp (double v1)  { throw new RuntimeException(); }
++  static public  int apply$mcID$sp (double v1)  { throw new RuntimeException(); }
++  static public  long apply$mcJD$sp (double v1)  { throw new RuntimeException(); }
++  static public  void apply$mcVD$sp (double v1)  { throw new RuntimeException(); }
++  static public  boolean apply$mcZF$sp (float v1)  { throw new RuntimeException(); }
++  static public  double apply$mcDF$sp (float v1)  { throw new RuntimeException(); }
++  static public  float apply$mcFF$sp (float v1)  { throw new RuntimeException(); }
++  static public  int apply$mcIF$sp (float v1)  { throw new RuntimeException(); }
++  static public  long apply$mcJF$sp (float v1)  { throw new RuntimeException(); }
++  static public  void apply$mcVF$sp (float v1)  { throw new RuntimeException(); }
++  static public  boolean apply$mcZI$sp (int v1)  { throw new RuntimeException(); }
++  static public  double apply$mcDI$sp (int v1)  { throw new RuntimeException(); }
++  static public  float apply$mcFI$sp (int v1)  { throw new RuntimeException(); }
++  static public  int apply$mcII$sp (int v1)  { throw new RuntimeException(); }
++  static public  long apply$mcJI$sp (int v1)  { throw new RuntimeException(); }
++  static public  void apply$mcVI$sp (int v1)  { throw new RuntimeException(); }
++  static public  boolean apply$mcZJ$sp (long v1)  { throw new RuntimeException(); }
++  static public  double apply$mcDJ$sp (long v1)  { throw new RuntimeException(); }
++  static public  float apply$mcFJ$sp (long v1)  { throw new RuntimeException(); }
++  static public  int apply$mcIJ$sp (long v1)  { throw new RuntimeException(); }
++  static public  long apply$mcJJ$sp (long v1)  { throw new RuntimeException(); }
++  static public  void apply$mcVJ$sp (long v1)  { throw new RuntimeException(); }
    public  Object messageId ()  { throw new RuntimeException(); }
-@@ -13,6 +13,7 @@
+   // not preceding
+   public   Identify (Object messageId)  { throw new RuntimeException(); }
+@@ -13,6 +37,7 @@
    public  Object productElement (int x$1)  { throw new RuntimeException(); }
    public  scala.collection.Iterator<java.lang.Object> productIterator ()  { throw new RuntimeException(); }
    public  boolean canEqual (Object x$1)  { throw new RuntimeException(); }
@@ -86,7 +112,7 @@
      public  java.lang.String d (java.lang.String a, akka.rk.buh.is.it.X b)  { throw new RuntimeException(); }
    }
    public  class C implements akka.rk.buh.is.it.X {
-@@ -98,8 +98,8 @@
+@@ -103,8 +103,8 @@
     * class A.C
     */
    static public  class C1 {
@@ -96,7 +122,7 @@
    }
    /**
     * object C1
-@@ -137,6 +137,11 @@
+@@ -142,6 +142,11 @@
    static public  java.lang.String stattic ()  { throw new RuntimeException(); }
    static public  java.lang.Object x ()  { throw new RuntimeException(); }
    /**
@@ -108,7 +134,7 @@
     * varargs
     * @param s (undocumented)
     * @return (undocumented)
-@@ -202,16 +207,11 @@
+@@ -207,16 +212,11 @@
     * @param s (undocumented)
     * @return (undocumented)
     */

--- a/plugin/src/test/resources/patches/2.13.1.patch
+++ b/plugin/src/test/resources/patches/2.13.1.patch
@@ -9,40 +9,14 @@
     */
 --- target/expected_output/basic/akka/actor/Identify.java
 +++ target/expected_output/basic/akka/actor/Identify.java
-@@ -1,7 +1,31 @@
+@@ -1,5 +1,5 @@
  package akka.actor;
 -public final class Identify implements scala.Product, scala.Serializable {
 +public final class Identify implements scala.Product, java.io.Serializable {
    static public  akka.actor.Identify apply (Object messageId)  { throw new RuntimeException(); }
    static public  scala.Option<java.lang.Object> unapply (akka.actor.Identify x$0)  { throw new RuntimeException(); }
-+  static public  boolean apply$mcZD$sp (double v1)  { throw new RuntimeException(); }
-+  static public  double apply$mcDD$sp (double v1)  { throw new RuntimeException(); }
-+  static public  float apply$mcFD$sp (double v1)  { throw new RuntimeException(); }
-+  static public  int apply$mcID$sp (double v1)  { throw new RuntimeException(); }
-+  static public  long apply$mcJD$sp (double v1)  { throw new RuntimeException(); }
-+  static public  void apply$mcVD$sp (double v1)  { throw new RuntimeException(); }
-+  static public  boolean apply$mcZF$sp (float v1)  { throw new RuntimeException(); }
-+  static public  double apply$mcDF$sp (float v1)  { throw new RuntimeException(); }
-+  static public  float apply$mcFF$sp (float v1)  { throw new RuntimeException(); }
-+  static public  int apply$mcIF$sp (float v1)  { throw new RuntimeException(); }
-+  static public  long apply$mcJF$sp (float v1)  { throw new RuntimeException(); }
-+  static public  void apply$mcVF$sp (float v1)  { throw new RuntimeException(); }
-+  static public  boolean apply$mcZI$sp (int v1)  { throw new RuntimeException(); }
-+  static public  double apply$mcDI$sp (int v1)  { throw new RuntimeException(); }
-+  static public  float apply$mcFI$sp (int v1)  { throw new RuntimeException(); }
-+  static public  int apply$mcII$sp (int v1)  { throw new RuntimeException(); }
-+  static public  long apply$mcJI$sp (int v1)  { throw new RuntimeException(); }
-+  static public  void apply$mcVI$sp (int v1)  { throw new RuntimeException(); }
-+  static public  boolean apply$mcZJ$sp (long v1)  { throw new RuntimeException(); }
-+  static public  double apply$mcDJ$sp (long v1)  { throw new RuntimeException(); }
-+  static public  float apply$mcFJ$sp (long v1)  { throw new RuntimeException(); }
-+  static public  int apply$mcIJ$sp (long v1)  { throw new RuntimeException(); }
-+  static public  long apply$mcJJ$sp (long v1)  { throw new RuntimeException(); }
-+  static public  void apply$mcVJ$sp (long v1)  { throw new RuntimeException(); }
    public  Object messageId ()  { throw new RuntimeException(); }
-   // not preceding
-   public   Identify (Object messageId)  { throw new RuntimeException(); }
-@@ -13,6 +37,7 @@
+@@ -13,6 +13,7 @@
    public  Object productElement (int x$1)  { throw new RuntimeException(); }
    public  scala.collection.Iterator<java.lang.Object> productIterator ()  { throw new RuntimeException(); }
    public  boolean canEqual (Object x$1)  { throw new RuntimeException(); }

--- a/plugin/src/test/resources/patches/2.13.1.patch
+++ b/plugin/src/test/resources/patches/2.13.1.patch
@@ -86,7 +86,7 @@
      public  java.lang.String d (java.lang.String a, akka.rk.buh.is.it.X b)  { throw new RuntimeException(); }
    }
    public  class C implements akka.rk.buh.is.it.X {
-@@ -98,8 +98,8 @@
+@@ -103,8 +103,8 @@
     * class A.C
     */
    static public  class C1 {
@@ -96,7 +96,7 @@
    }
    /**
     * object C1
-@@ -137,6 +137,11 @@
+@@ -142,6 +142,11 @@
    static public  java.lang.String stattic ()  { throw new RuntimeException(); }
    static public  java.lang.Object x ()  { throw new RuntimeException(); }
    /**
@@ -108,7 +108,7 @@
     * varargs
     * @param s (undocumented)
     * @return (undocumented)
-@@ -202,16 +207,11 @@
+@@ -207,16 +212,11 @@
     * @param s (undocumented)
     * @return (undocumented)
     */

--- a/plugin/src/test/resources/patches/2.13.2.patch
+++ b/plugin/src/test/resources/patches/2.13.2.patch
@@ -9,40 +9,14 @@
     */
 --- target/expected_output/basic/akka/actor/Identify.java
 +++ target/expected_output/basic/akka/actor/Identify.java
-@@ -1,7 +1,31 @@
+@@ -1,5 +1,5 @@
  package akka.actor;
 -public final class Identify implements scala.Product, scala.Serializable {
 +public final class Identify implements scala.Product, java.io.Serializable {
    static public  akka.actor.Identify apply (Object messageId)  { throw new RuntimeException(); }
    static public  scala.Option<java.lang.Object> unapply (akka.actor.Identify x$0)  { throw new RuntimeException(); }
-+  static public  boolean apply$mcZD$sp (double v1)  { throw new RuntimeException(); }
-+  static public  double apply$mcDD$sp (double v1)  { throw new RuntimeException(); }
-+  static public  float apply$mcFD$sp (double v1)  { throw new RuntimeException(); }
-+  static public  int apply$mcID$sp (double v1)  { throw new RuntimeException(); }
-+  static public  long apply$mcJD$sp (double v1)  { throw new RuntimeException(); }
-+  static public  void apply$mcVD$sp (double v1)  { throw new RuntimeException(); }
-+  static public  boolean apply$mcZF$sp (float v1)  { throw new RuntimeException(); }
-+  static public  double apply$mcDF$sp (float v1)  { throw new RuntimeException(); }
-+  static public  float apply$mcFF$sp (float v1)  { throw new RuntimeException(); }
-+  static public  int apply$mcIF$sp (float v1)  { throw new RuntimeException(); }
-+  static public  long apply$mcJF$sp (float v1)  { throw new RuntimeException(); }
-+  static public  void apply$mcVF$sp (float v1)  { throw new RuntimeException(); }
-+  static public  boolean apply$mcZI$sp (int v1)  { throw new RuntimeException(); }
-+  static public  double apply$mcDI$sp (int v1)  { throw new RuntimeException(); }
-+  static public  float apply$mcFI$sp (int v1)  { throw new RuntimeException(); }
-+  static public  int apply$mcII$sp (int v1)  { throw new RuntimeException(); }
-+  static public  long apply$mcJI$sp (int v1)  { throw new RuntimeException(); }
-+  static public  void apply$mcVI$sp (int v1)  { throw new RuntimeException(); }
-+  static public  boolean apply$mcZJ$sp (long v1)  { throw new RuntimeException(); }
-+  static public  double apply$mcDJ$sp (long v1)  { throw new RuntimeException(); }
-+  static public  float apply$mcFJ$sp (long v1)  { throw new RuntimeException(); }
-+  static public  int apply$mcIJ$sp (long v1)  { throw new RuntimeException(); }
-+  static public  long apply$mcJJ$sp (long v1)  { throw new RuntimeException(); }
-+  static public  void apply$mcVJ$sp (long v1)  { throw new RuntimeException(); }
    public  Object messageId ()  { throw new RuntimeException(); }
-   // not preceding
-   public   Identify (Object messageId)  { throw new RuntimeException(); }
-@@ -13,6 +37,7 @@
+@@ -13,6 +13,7 @@
    public  Object productElement (int x$1)  { throw new RuntimeException(); }
    public  scala.collection.Iterator<java.lang.Object> productIterator ()  { throw new RuntimeException(); }
    public  boolean canEqual (Object x$1)  { throw new RuntimeException(); }
@@ -112,7 +86,7 @@
      public  java.lang.String d (java.lang.String a, akka.rk.buh.is.it.X b)  { throw new RuntimeException(); }
    }
    public  class C implements akka.rk.buh.is.it.X {
-@@ -98,8 +98,8 @@
+@@ -103,8 +103,8 @@
     * class A.C
     */
    static public  class C1 {
@@ -122,7 +96,7 @@
    }
    /**
     * object C1
-@@ -137,6 +137,11 @@
+@@ -142,6 +142,11 @@
    static public  java.lang.String stattic ()  { throw new RuntimeException(); }
    static public  java.lang.Object x ()  { throw new RuntimeException(); }
    /**
@@ -134,7 +108,7 @@
     * varargs
     * @param s (undocumented)
     * @return (undocumented)
-@@ -202,16 +207,11 @@
+@@ -207,16 +212,11 @@
     * @param s (undocumented)
     * @return (undocumented)
     */


### PR DESCRIPTION
`runsAfter` is set to `fields`. However, in reality the phase
assembly algorithm used in 2.12.9 and before, also 2.13.0, places the
`GenJavadoc` phase right after `specialize`, which is valid, but probably
not intended.

With some changes in the phase assembly algorithm in 2.13.1, the
`GenJavadoc` phase was now placed right after `fields`, which caused
tests to fail.