### PR TITLE
Revert back to sbt 0.13.17

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.2.8
+sbt.version=0.13.17

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,2 +1,2 @@
-addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.1.2")
+addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.1.1")
 addSbtPlugin("com.dwijnand" % "sbt-dynver" % "3.3.0")


### PR DESCRIPTION
Refs #193

To make sure publishing uses the expected path again. Of course it would be
better to make this work with sbt1, but I'm not sure how.