### PR TITLE
Use sbt 1.3 and sbt-ci-release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -65,7 +65,7 @@ jobs:
       # Increasing ReservedCodeCacheSize minimizes scala compiler-interface compile times
       script: sbt -J-XX:ReservedCodeCacheSize=256M ++$SCALA_VERSION test
     - stage: release
-      script: echo $PGP_SECRET | base64 --decode | gpg --import && sbt +publishSigned
+      script: sbt ci-release
 
 before_cache:
   - find $HOME/.sbt -name "*.lock" | xargs rm

--- a/build.sbt
+++ b/build.sbt
@@ -70,30 +70,6 @@ lazy val defaults = Seq(
   },
   scalaMajorVersion := CrossVersion.partialVersion(scalaVersion.value).get._2.toInt,
   resolvers += Resolver.mavenLocal,
-  publishTo := {
-    if (version.value endsWith "-SNAPSHOT") Some("snapshots" at "https://oss.sonatype.org/content/repositories/snapshots")
-    else Some("releases" at "https://oss.sonatype.org/service/local/staging/deploy/maven2")
-  },
-  // This should no longer be necessary once we update to sbt-ci-release
-  // https://github.com/lightbend/genjavadoc/issues/203
-  credentials ++= {
-    val alreadyContainsSonatypeCredentials = credentials.value.collect {
-      case d: DirectCredentials => d.host == "oss.sonatype.org"
-    }.nonEmpty
-    if (!alreadyContainsSonatypeCredentials) {
-      val env = sys.env.get(_)
-      (for {
-        username <- env("SONATYPE_USERNAME")
-        password <- env("SONATYPE_PASSWORD")
-      } yield
-        Credentials(
-          "Sonatype Nexus Repository Manager",
-          "oss.sonatype.org",
-          username,
-          password
-        )).toSeq
-    } else Seq.empty
-  },
   startYear := Some(2012),
   homepage := Some(url("https://github.com/lightbend/genjavadoc")),
   licenses := Seq("Apache-2.0" -> url("http://opensource.org/licenses/Apache-2.0")),

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.17
+sbt.version=1.3.3

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,2 +1,1 @@
-addSbtPlugin("com.jsuereth" % "sbt-pgp" % "2.0.0")
-addSbtPlugin("com.dwijnand" % "sbt-dynver" % "4.0.0")
+addSbtPlugin("com.geirsson" % "sbt-ci-release" % "1.4.31")


### PR DESCRIPTION
References #193, #203.
The issue with publishLocal mentioned in #193 seems to have disappeared.

This should also use sonatype bundle uploads for releasing, which might
speed up the travis release enough so it completes within the deadline.
Still needs to be tested, though, because that feature is only used when
doing non-snapshot releases. We should probably release an RC first to
test the process.