### PR TITLE
more robust annotation retrieval

### DIFF
--- a/src/main/scala/com/typesafe/genjavadoc/BasicTransform.scala
+++ b/src/main/scala/com/typesafe/genjavadoc/BasicTransform.scala
@@ -160,7 +160,7 @@ trait BasicTransform { this: TransformCake =>
   private def deprecationInfo(d: ImplDef): Option[DeprecationInfo] = deprecationInfo(d.symbol)
   private def deprecationInfo(symbol: Symbol): Option[DeprecationInfo] =
     if (symbol.isDeprecated) {
-      val deprec = symbol.annotations.find(_.toString contains "deprecated(").get
+      val deprec = symbol.getAnnotation(definitions.DeprecatedAttr).get
       Some(DeprecationInfo(deprec.stringArg(0).getOrElse(""), deprec.stringArg(1).getOrElse("")))
     } else None
 


### PR DESCRIPTION
This started to fail with 2.13.6 as annotation.toString was just `deprecated` for the companion object. The case class symbol annotation toString itself still seems to contain the parameters.

@SethTisue do you know whether that might have been a change only in `toString` behavior between 2.13.5 and 2.13.6 or if copying over annotations from `case class` to it's generated companion object might have changed?

Fixes #286.