### PR TITLE
Support 2.12.14 in build.sbt

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -50,7 +50,7 @@ lazy val defaults = Seq(
     // 2.11.6 is the first to be supported and we skip 2.11.9 and 2.11.10
     val supportedScala211Versions = Seq("2.11.6", "2.11.7", "2.11.8", "2.11.11", "2.11.12")
     // Scala 2.12.[0-2] are not supported
-    val supportedScala212Versions = (3 to 13).map(p => s"2.12.$p")
+    val supportedScala212Versions = (3 to 14).map(p => s"2.12.$p")
     val supportedScala213Versions = (0 to 6).map(p => s"2.13.$p")
     supportedScala211Versions ++ supportedScala212Versions ++ supportedScala213Versions
   },


### PR DESCRIPTION
There were some commits trying to introduce 2.12.14 but none of those change it here in the supported versions.